### PR TITLE
Add scene module runtime debug logs

### DIFF
--- a/Packages/UGF.Module.Scenes/Runtime/Loaders.Manager/ManagerSceneLoader.Logs.cs
+++ b/Packages/UGF.Module.Scenes/Runtime/Loaders.Manager/ManagerSceneLoader.Logs.cs
@@ -1,0 +1,111 @@
+﻿using System.Diagnostics;
+using UGF.Logs.Runtime;
+using UnityEngine.SceneManagement;
+
+namespace UGF.Module.Scenes.Runtime.Loaders.Manager
+{
+    public partial class ManagerSceneLoader
+    {
+        [Conditional("UNITY_EDITOR")]
+        [Conditional(LogUtility.LOG_DEBUG_DEFINE)]
+        private static void LogSceneLoading(string id, ManagerSceneInfo info, SceneLoadParameters parameters, bool isAsync = false)
+        {
+            Log.Debug("Manager Scene Loader loading", new
+            {
+                id,
+                info = new
+                {
+                    info.LoaderId,
+                    info.SceneId
+                },
+                parameters = new
+                {
+                    parameters.AddMode,
+                    parameters.PhysicsMode
+                },
+                isAsync
+            });
+        }
+
+        [Conditional("UNITY_EDITOR")]
+        [Conditional(LogUtility.LOG_DEBUG_DEFINE)]
+        private static void LogSceneLoaded(string id, ManagerSceneInfo info, SceneLoadParameters parameters, Scene scene, bool isAsync = false)
+        {
+            Log.Debug("Manager Scene Loader loaded", new
+            {
+                id,
+                info = new
+                {
+                    info.LoaderId,
+                    info.SceneId
+                },
+                parameters = new
+                {
+                    parameters.AddMode,
+                    parameters.PhysicsMode
+                },
+                scene = new
+                {
+                    scene.handle,
+                    scene.name,
+                    scene.path,
+                    scene.buildIndex,
+                    scene.rootCount,
+                    scene.isSubScene
+                },
+                isAsync
+            });
+        }
+
+        [Conditional("UNITY_EDITOR")]
+        [Conditional(LogUtility.LOG_DEBUG_DEFINE)]
+        private static void LogSceneUnload(string id, ManagerSceneInfo info, SceneUnloadParameters parameters, Scene scene, bool unloadUnused, bool isAsync = false)
+        {
+            Log.Debug("Manager Scene Loader unloading", new
+            {
+                id,
+                info = new
+                {
+                    info.LoaderId,
+                    info.SceneId
+                },
+                parameters = new
+                {
+                    parameters.Options
+                },
+                scene = new
+                {
+                    scene.handle,
+                    scene.name,
+                    scene.path,
+                    scene.buildIndex,
+                    scene.rootCount,
+                    scene.isSubScene
+                },
+                unloadUnused,
+                isAsync
+            });
+        }
+
+        [Conditional("UNITY_EDITOR")]
+        [Conditional(LogUtility.LOG_DEBUG_DEFINE)]
+        private static void LogSceneUnloaded(string id, ManagerSceneInfo info, SceneUnloadParameters parameters, bool unloadUnused, bool isAsync = false)
+        {
+            Log.Debug("Manager Scene Loader unloaded", new
+            {
+                id,
+                info = new
+                {
+                    info.LoaderId,
+                    info.SceneId
+                },
+                parameters = new
+                {
+                    parameters.Options
+                },
+                unloadUnused,
+                isAsync
+            });
+        }
+    }
+}

--- a/Packages/UGF.Module.Scenes/Runtime/Loaders.Manager/ManagerSceneLoader.Logs.cs.meta
+++ b/Packages/UGF.Module.Scenes/Runtime/Loaders.Manager/ManagerSceneLoader.Logs.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: bcfee07e97e54efca1c06c415dfe2d41
+timeCreated: 1605204109

--- a/Packages/UGF.Module.Scenes/Runtime/Loaders.Manager/ManagerSceneLoader.cs
+++ b/Packages/UGF.Module.Scenes/Runtime/Loaders.Manager/ManagerSceneLoader.cs
@@ -4,7 +4,7 @@ using UnityEngine.SceneManagement;
 
 namespace UGF.Module.Scenes.Runtime.Loaders.Manager
 {
-    public class ManagerSceneLoader : SceneLoader<ManagerSceneInfo>
+    public partial class ManagerSceneLoader : SceneLoader<ManagerSceneInfo>
     {
         public bool UnloadUnusedAfterUnload { get; }
 
@@ -15,16 +15,22 @@ namespace UGF.Module.Scenes.Runtime.Loaders.Manager
 
         protected override Scene OnLoad(ISceneProvider provider, string id, ManagerSceneInfo info, SceneLoadParameters parameters)
         {
+            LogSceneLoading(id, info, parameters);
+
             string scenePath = ManagerSceneSettings.GetScenePath(info.SceneId);
             var options = new LoadSceneParameters(parameters.AddMode, parameters.PhysicsMode);
 
             Scene scene = SceneManager.LoadScene(scenePath, options);
+
+            LogSceneLoaded(id, info, parameters, scene);
 
             return scene;
         }
 
         protected override async Task<Scene> OnLoadAsync(ISceneProvider provider, string id, ManagerSceneInfo info, SceneLoadParameters parameters)
         {
+            LogSceneLoading(id, info, parameters, true);
+
             string scenePath = ManagerSceneSettings.GetScenePath(info.SceneId);
             var options = new LoadSceneParameters(parameters.AddMode, parameters.PhysicsMode);
 
@@ -36,21 +42,29 @@ namespace UGF.Module.Scenes.Runtime.Loaders.Manager
                 await Task.Yield();
             }
 
+            LogSceneLoaded(id, info, parameters, scene, true);
+
             return scene;
         }
 
         protected override void OnUnload(ISceneProvider provider, string id, Scene scene, ManagerSceneInfo info, SceneUnloadParameters parameters)
         {
+            LogSceneUnload(id, info, parameters, scene, UnloadUnusedAfterUnload);
+
             SceneUtility.UnloadScene(scene, parameters.Options);
 
             if (UnloadUnusedAfterUnload)
             {
                 Resources.UnloadUnusedAssets();
             }
+
+            LogSceneUnloaded(id, info, parameters, UnloadUnusedAfterUnload);
         }
 
         protected override async Task OnUnloadAsync(ISceneProvider provider, string id, Scene scene, ManagerSceneInfo info, SceneUnloadParameters parameters)
         {
+            LogSceneUnload(id, info, parameters, scene, UnloadUnusedAfterUnload, true);
+
             AsyncOperation operation = SceneManager.UnloadSceneAsync(scene, parameters.Options);
 
             while (!operation.isDone)
@@ -67,6 +81,8 @@ namespace UGF.Module.Scenes.Runtime.Loaders.Manager
                     await Task.Yield();
                 }
             }
+
+            LogSceneUnloaded(id, info, parameters, UnloadUnusedAfterUnload, true);
         }
     }
 }

--- a/Packages/UGF.Module.Scenes/Runtime/SceneModule.Logs.cs
+++ b/Packages/UGF.Module.Scenes/Runtime/SceneModule.Logs.cs
@@ -1,0 +1,89 @@
+﻿using System.Diagnostics;
+using UGF.Logs.Runtime;
+using UnityEngine.SceneManagement;
+
+namespace UGF.Module.Scenes.Runtime
+{
+    public partial class SceneModule
+    {
+        [Conditional("UNITY_EDITOR")]
+        [Conditional(LogUtility.LOG_DEBUG_DEFINE)]
+        private static void LogSceneLoad(string id, SceneLoadParameters parameters, bool isAsync = false)
+        {
+            Log.Debug("Scene loading", new
+            {
+                id,
+                parameters = new
+                {
+                    parameters.AddMode,
+                    parameters.PhysicsMode
+                },
+                isAsync
+            });
+        }
+
+        [Conditional("UNITY_EDITOR")]
+        [Conditional(LogUtility.LOG_DEBUG_DEFINE)]
+        private static void LogSceneLoaded(string id, Scene scene, SceneLoadParameters parameters, bool isAsync = false)
+        {
+            Log.Debug("Scene loaded", new
+            {
+                id,
+                scene = new
+                {
+                    scene.handle,
+                    scene.name,
+                    scene.path,
+                    scene.buildIndex,
+                    scene.rootCount,
+                    scene.isSubScene
+                },
+                parameters = new
+                {
+                    parameters.AddMode,
+                    parameters.PhysicsMode
+                },
+                isAsync
+            });
+        }
+
+        [Conditional("UNITY_EDITOR")]
+        [Conditional(LogUtility.LOG_DEBUG_DEFINE)]
+        private static void LogSceneUnload(string id, Scene scene, SceneUnloadParameters parameters, bool isAsync = false)
+        {
+            Log.Debug("Scene unloading", new
+            {
+                id,
+                scene = new
+                {
+                    scene.handle,
+                    scene.name,
+                    scene.path,
+                    scene.buildIndex,
+                    scene.rootCount,
+                    scene.isSubScene
+                },
+                parameters = new
+                {
+                    parameters.Options
+                },
+                isAsync
+            });
+        }
+
+        [Conditional("UNITY_EDITOR")]
+        [Conditional(LogUtility.LOG_DEBUG_DEFINE)]
+        private static void LogSceneUnloaded(string id, SceneUnloadParameters parameters, bool isAsync = false)
+        {
+            Log.Debug("Scene unloaded", new
+            {
+                id,
+                parameters = new
+                {
+                    parameters.Options
+                },
+                isAsync
+            });
+        }
+    }
+}

--- a/Packages/UGF.Module.Scenes/Runtime/SceneModule.Logs.cs.meta
+++ b/Packages/UGF.Module.Scenes/Runtime/SceneModule.Logs.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 6173b824bcd4407f90ac6d511b0301fe
+timeCreated: 1605202286

--- a/Packages/UGF.Module.Scenes/Runtime/UGF.Module.Scenes.Runtime.asmdef
+++ b/Packages/UGF.Module.Scenes/Runtime/UGF.Module.Scenes.Runtime.asmdef
@@ -5,7 +5,8 @@
         "GUID:a4312e46e9f64bb4aa011ac96ffd2a61",
         "GUID:d067af32d09350a4bb33960432735e4d",
         "GUID:088d00b6871540e44bce58af1a3f0f17",
-        "GUID:ff62901452104d14cae29322ac133c05"
+        "GUID:ff62901452104d14cae29322ac133c05",
+        "GUID:6ca210c6fc8b79d4292f3cdb1061c73e"
     ],
     "includePlatforms": [],
     "excludePlatforms": [],

--- a/ProjectSettings/Packages/UGF.Logs/LogEditorSettings.asset
+++ b/ProjectSettings/Packages/UGF.Logs/LogEditorSettings.asset
@@ -14,6 +14,24 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   m_editorEnabled: 1
   m_settings:
-    m_groups: []
+    m_groups:
+    - m_name: Standalone
+      m_settings:
+        id: 0
   references:
     version: 1
+    00000000:
+      type: {class: DefinesSettings, ns: UGF.Defines.Editor, asm: UGF.Defines.Editor}
+      data:
+        m_includeInBuild: 1
+        m_defines:
+        - m_enabled: 0
+          m_value: UGF_LOG_INFO
+        - m_enabled: 1
+          m_value: UGF_LOG_DEBUG
+        - m_enabled: 0
+          m_value: UGF_LOG_WARNING
+        - m_enabled: 0
+          m_value: UGF_LOG_ERROR
+        - m_enabled: 0
+          m_value: UGF_LOG_EXCEPTION


### PR DESCRIPTION
- Add logs for `SceneModule` initialize and uninitialize events.
- Add logs for `SceneModule` and `ManagerSceneLoader` of loading and unloading events.