### PR TITLE
Update to support latest application package

### DIFF
--- a/Assets/UGF.Module.Scenes.Runtime.Tests/Resources/SceneTest.unity
+++ b/Assets/UGF.Module.Scenes.Runtime.Tests/Resources/SceneTest.unity
@@ -290,3 +290,47 @@ Transform:
   m_Father: {fileID: 0}
   m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 50, y: -30, z: 0}
+--- !u!1 &1604289255
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1604289256}
+  - component: {fileID: 1604289257}
+  m_Layer: 0
+  m_Name: Container
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1604289256
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1604289255}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 2
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &1604289257
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1604289255}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 723f2b4bea3f40a4843634d5553d4f50, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_containers: []

--- a/Assets/UGF.Module.Scenes.Runtime.Tests/TestSceneModule.cs
+++ b/Assets/UGF.Module.Scenes.Runtime.Tests/TestSceneModule.cs
@@ -93,7 +93,7 @@ namespace UGF.Module.Scenes.Runtime.Tests
                 {
                     Modules =
                     {
-                        (IApplicationModuleAsset)Resources.Load(moduleName, typeof(IApplicationModuleAsset))
+                        (IApplicationModuleBuilder)Resources.Load(moduleName, typeof(IApplicationModuleBuilder))
                     }
                 }
             });

--- a/Assets/UGF.Module.Scenes.Runtime.Tests/UGF.Module.Scenes.Runtime.Tests.asmdef
+++ b/Assets/UGF.Module.Scenes.Runtime.Tests/UGF.Module.Scenes.Runtime.Tests.asmdef
@@ -5,6 +5,8 @@
         "GUID:e95b3da452542ae4b995fb0ece7e6d10",
         "GUID:a4312e46e9f64bb4aa011ac96ffd2a61",
         "GUID:d067af32d09350a4bb33960432735e4d",
+        "GUID:6c7389a7d4bbed54e96eb1e71a69798e",
+        "GUID:3ad3a680cb737c6428dc532d551e7bb7",
         "GUID:27619889b8ba8c24980f49ee34dbb44a"
     ],
     "includePlatforms": [],

--- a/Packages/UGF.Module.Scenes/Editor/SceneModuleAssetEditor.cs
+++ b/Packages/UGF.Module.Scenes/Editor/SceneModuleAssetEditor.cs
@@ -1,5 +1,4 @@
-﻿using UGF.Application.Editor;
-using UGF.EditorTools.Editor.IMGUI.AssetReferences;
+﻿using UGF.EditorTools.Editor.IMGUI.AssetReferences;
 using UGF.EditorTools.Editor.IMGUI.Scopes;
 using UGF.Module.Scenes.Runtime;
 using UnityEditor;
@@ -7,7 +6,7 @@ using UnityEditor;
 namespace UGF.Module.Scenes.Editor
 {
     [CustomEditor(typeof(SceneModuleAsset), true)]
-    internal class SceneModuleAssetEditor : ApplicationModuleAssetEditor
+    internal class SceneModuleAssetEditor : UnityEditor.Editor
     {
         private SerializedProperty m_propertyScript;
         private SerializedProperty m_propertyUnloadTrackedScenesOnUninitialize;
@@ -46,8 +45,6 @@ namespace UGF.Module.Scenes.Editor
                 m_listLoaders.DrawGUILayout();
                 m_listScenes.DrawGUILayout();
             }
-
-            DrawModuleRegisterTypeInfo();
         }
     }
 }

--- a/Packages/UGF.Module.Scenes/Runtime/ISceneModule.cs
+++ b/Packages/UGF.Module.Scenes/Runtime/ISceneModule.cs
@@ -5,7 +5,7 @@ using UnityEngine.SceneManagement;
 
 namespace UGF.Module.Scenes.Runtime
 {
-    public interface ISceneModule : IApplicationModuleDescribed
+    public interface ISceneModule : IApplicationModule
     {
         new ISceneModuleDescription Description { get; }
         ISceneProvider Provider { get; }

--- a/Packages/UGF.Module.Scenes/Runtime/Loaders.Manager/ManagerSceneInfoAsset.cs
+++ b/Packages/UGF.Module.Scenes/Runtime/Loaders.Manager/ManagerSceneInfoAsset.cs
@@ -4,7 +4,7 @@ using UnityEngine.SceneManagement;
 
 namespace UGF.Module.Scenes.Runtime.Loaders.Manager
 {
-    [CreateAssetMenu(menuName = "UGF/Scenes/Manager Scene Info", order = 2000)]
+    [CreateAssetMenu(menuName = "Unity Game Framework/Scenes/Manager Scene Info", order = 2000)]
     public class ManagerSceneInfoAsset : SceneInfoAssetBase
     {
         [AssetGuid(typeof(SceneLoaderAssetBase))]

--- a/Packages/UGF.Module.Scenes/Runtime/Loaders.Manager/ManagerSceneLoaderAsset.cs
+++ b/Packages/UGF.Module.Scenes/Runtime/Loaders.Manager/ManagerSceneLoaderAsset.cs
@@ -2,7 +2,7 @@
 
 namespace UGF.Module.Scenes.Runtime.Loaders.Manager
 {
-    [CreateAssetMenu(menuName = "UGF/Scenes/Manager Scene Loader", order = 2000)]
+    [CreateAssetMenu(menuName = "Unity Game Framework/Scenes/Manager Scene Loader", order = 2000)]
     public class ManagerSceneLoaderAsset : SceneLoaderAssetBase
     {
         [SerializeField] private bool m_unloadUnusedAfterUnload;

--- a/Packages/UGF.Module.Scenes/Runtime/SceneContainer.cs
+++ b/Packages/UGF.Module.Scenes/Runtime/SceneContainer.cs
@@ -4,6 +4,7 @@ using UnityEngine;
 
 namespace UGF.Module.Scenes.Runtime
 {
+    [AddComponentMenu("Unity Game Framework/Scenes/Scene Container", 2000)]
     public class SceneContainer : MonoBehaviour
     {
         [SerializeField] private List<Component> m_containers = new List<Component>();

--- a/Packages/UGF.Module.Scenes/Runtime/SceneInfoAsset.cs
+++ b/Packages/UGF.Module.Scenes/Runtime/SceneInfoAsset.cs
@@ -4,7 +4,7 @@ using UnityEngine.SceneManagement;
 
 namespace UGF.Module.Scenes.Runtime
 {
-    [CreateAssetMenu(menuName = "UGF/Scenes/Scene Info", order = 2000)]
+    [CreateAssetMenu(menuName = "Unity Game Framework/Scenes/Scene Info", order = 2000)]
     public class SceneInfoAsset : SceneInfoAssetBase
     {
         [AssetGuid(typeof(SceneLoaderAssetBase))]

--- a/Packages/UGF.Module.Scenes/Runtime/SceneInfoAssetBase.cs
+++ b/Packages/UGF.Module.Scenes/Runtime/SceneInfoAssetBase.cs
@@ -1,19 +1,8 @@
-﻿using UnityEngine;
+﻿using UGF.Builder.Runtime;
 
 namespace UGF.Module.Scenes.Runtime
 {
-    public abstract class SceneInfoAssetBase : ScriptableObject
+    public abstract class SceneInfoAssetBase : BuilderAsset<ISceneInfo>
     {
-        public T Build<T>() where T : class, ISceneInfo
-        {
-            return (T)OnBuild();
-        }
-
-        public ISceneInfo Build()
-        {
-            return OnBuild();
-        }
-
-        protected abstract ISceneInfo OnBuild();
     }
 }

--- a/Packages/UGF.Module.Scenes/Runtime/SceneLoaderAssetBase.cs
+++ b/Packages/UGF.Module.Scenes/Runtime/SceneLoaderAssetBase.cs
@@ -1,19 +1,8 @@
-﻿using UnityEngine;
+﻿using UGF.Builder.Runtime;
 
 namespace UGF.Module.Scenes.Runtime
 {
-    public abstract class SceneLoaderAssetBase : ScriptableObject
+    public abstract class SceneLoaderAssetBase : BuilderAsset<ISceneLoader>
     {
-        public T Build<T>() where T : class, ISceneLoader
-        {
-            return (T)OnBuild();
-        }
-
-        public ISceneLoader Build()
-        {
-            return OnBuild();
-        }
-
-        protected abstract ISceneLoader OnBuild();
     }
 }

--- a/Packages/UGF.Module.Scenes/Runtime/SceneModule.cs
+++ b/Packages/UGF.Module.Scenes/Runtime/SceneModule.cs
@@ -9,7 +9,7 @@ using UnityEngine.SceneManagement;
 
 namespace UGF.Module.Scenes.Runtime
 {
-    public partial class SceneModule : ApplicationModuleDescribed<SceneModuleDescription>, ISceneModule
+    public partial class SceneModule : ApplicationModule<SceneModuleDescription>, ISceneModule
     {
         public ISceneProvider Provider { get; }
         public IReadOnlyDictionary<Scene, SceneInstance> Scenes { get; }
@@ -23,9 +23,13 @@ namespace UGF.Module.Scenes.Runtime
 
         private readonly Dictionary<Scene, SceneInstance> m_scenes = new Dictionary<Scene, SceneInstance>();
 
-        public SceneModule(IApplication application, SceneModuleDescription description, ISceneProvider provider = null) : base(application, description)
+        public SceneModule(SceneModuleDescription description, IApplication application) : this(description, application, new SceneProvider())
         {
-            Provider = provider ?? new SceneProvider();
+        }
+
+        public SceneModule(SceneModuleDescription description, IApplication application, ISceneProvider provider) : base(description, application)
+        {
+            Provider = provider ?? throw new ArgumentNullException(nameof(provider));
             Scenes = new ReadOnlyDictionary<Scene, SceneInstance>(m_scenes);
         }
 

--- a/Packages/UGF.Module.Scenes/Runtime/SceneModuleAsset.cs
+++ b/Packages/UGF.Module.Scenes/Runtime/SceneModuleAsset.cs
@@ -6,7 +6,7 @@ using UnityEngine;
 namespace UGF.Module.Scenes.Runtime
 {
     [CreateAssetMenu(menuName = "UGF/Scenes/Scene Module", order = 2000)]
-    public class SceneModuleAsset : ApplicationModuleDescribedAsset<ISceneModule, SceneModuleDescription>
+    public class SceneModuleAsset : ApplicationModuleAsset<ISceneModule, SceneModuleDescription>
     {
         [SerializeField] private bool m_unloadTrackedScenesOnUninitialize = true;
         [SerializeField] private List<AssetReference<SceneLoaderAssetBase>> m_loaders = new List<AssetReference<SceneLoaderAssetBase>>();
@@ -16,9 +16,9 @@ namespace UGF.Module.Scenes.Runtime
         public List<AssetReference<SceneLoaderAssetBase>> Loaders { get { return m_loaders; } }
         public List<AssetReference<SceneInfoAssetBase>> Scenes { get { return m_scenes; } }
 
-        protected override SceneModuleDescription OnGetDescription(IApplication application)
+        protected override IApplicationModuleDescription OnBuildDescription()
         {
-            var description = new SceneModuleDescription
+            var description = new SceneModuleDescription(typeof(ISceneModule))
             {
                 UnloadTrackedScenesOnUninitialize = m_unloadTrackedScenesOnUninitialize
             };
@@ -42,9 +42,9 @@ namespace UGF.Module.Scenes.Runtime
             return description;
         }
 
-        protected override ISceneModule OnBuild(IApplication application, SceneModuleDescription description)
+        protected override ISceneModule OnBuild(SceneModuleDescription description, IApplication application)
         {
-            return new SceneModule(application, description);
+            return new SceneModule(description, application);
         }
     }
 }

--- a/Packages/UGF.Module.Scenes/Runtime/SceneModuleAsset.cs
+++ b/Packages/UGF.Module.Scenes/Runtime/SceneModuleAsset.cs
@@ -5,7 +5,7 @@ using UnityEngine;
 
 namespace UGF.Module.Scenes.Runtime
 {
-    [CreateAssetMenu(menuName = "UGF/Scenes/Scene Module", order = 2000)]
+    [CreateAssetMenu(menuName = "Unity Game Framework/Scenes/Scene Module", order = 2000)]
     public class SceneModuleAsset : ApplicationModuleAsset<ISceneModule, SceneModuleDescription>
     {
         [SerializeField] private bool m_unloadTrackedScenesOnUninitialize = true;

--- a/Packages/UGF.Module.Scenes/Runtime/SceneModuleDescription.cs
+++ b/Packages/UGF.Module.Scenes/Runtime/SceneModuleDescription.cs
@@ -1,8 +1,10 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
+using UGF.Application.Runtime;
 
 namespace UGF.Module.Scenes.Runtime
 {
-    public class SceneModuleDescription : ISceneModuleDescription
+    public class SceneModuleDescription : ApplicationModuleDescription, ISceneModuleDescription
     {
         public Dictionary<string, ISceneLoader> Loaders { get; } = new Dictionary<string, ISceneLoader>();
         public Dictionary<string, ISceneInfo> Scenes { get; } = new Dictionary<string, ISceneInfo>();
@@ -10,5 +12,9 @@ namespace UGF.Module.Scenes.Runtime
 
         IReadOnlyDictionary<string, ISceneLoader> ISceneModuleDescription.Loaders { get { return Loaders; } }
         IReadOnlyDictionary<string, ISceneInfo> ISceneModuleDescription.Scenes { get { return Scenes; } }
+
+        public SceneModuleDescription(Type registerType) : base(registerType)
+        {
+        }
     }
 }

--- a/Packages/UGF.Module.Scenes/Runtime/UGF.Module.Scenes.Runtime.asmdef
+++ b/Packages/UGF.Module.Scenes/Runtime/UGF.Module.Scenes.Runtime.asmdef
@@ -6,6 +6,8 @@
         "GUID:d067af32d09350a4bb33960432735e4d",
         "GUID:088d00b6871540e44bce58af1a3f0f17",
         "GUID:ff62901452104d14cae29322ac133c05",
+        "GUID:6c7389a7d4bbed54e96eb1e71a69798e",
+        "GUID:3ad3a680cb737c6428dc532d551e7bb7",
         "GUID:6ca210c6fc8b79d4292f3cdb1061c73e"
     ],
     "includePlatforms": [],

--- a/Packages/UGF.Module.Scenes/package.json
+++ b/Packages/UGF.Module.Scenes/package.json
@@ -22,8 +22,7 @@
     "registry": "https://api.bintray.com/content/unity-game-framework/public"
   },
   "dependencies": {
-    "com.ugf.application": "5.3.0",
-    "com.ugf.customsettings": "3.2.0",
-    "com.ugf.logs": "4.0.0"
+    "com.ugf.application": "6.0.0",
+    "com.ugf.logs": "4.1.0"
   }
 }

--- a/Packages/manifest.json
+++ b/Packages/manifest.json
@@ -1,7 +1,7 @@
 {
   "dependencies": {
-    "com.unity.ide.rider": "2.0.7",
-    "com.unity.test-framework": "1.1.18"
+    "com.unity.ide.rider": "3.0.3",
+    "com.unity.test-framework": "1.1.19"
   },
   "scopedRegistries": [
     {

--- a/Packages/manifest.json
+++ b/Packages/manifest.json
@@ -1,5 +1,8 @@
 {
   "dependencies": {
+    "com.ugf.application": "file:D:/Workspace/Unity Game Framework/ugf-application/Packages/UGF.Application",
+    "com.ugf.builder": "file:D:/Workspace/Unity Game Framework/ugf-builder/Packages/UGF.Builder",
+    "com.ugf.description": "file:D:/Workspace/Unity Game Framework/ugf-description/Packages/UGF.Description",
     "com.unity.ide.rider": "3.0.3",
     "com.unity.test-framework": "1.1.19"
   },

--- a/Packages/manifest.json
+++ b/Packages/manifest.json
@@ -1,8 +1,5 @@
 {
   "dependencies": {
-    "com.ugf.application": "file:D:/Workspace/Unity Game Framework/ugf-application/Packages/UGF.Application",
-    "com.ugf.builder": "file:D:/Workspace/Unity Game Framework/ugf-builder/Packages/UGF.Builder",
-    "com.ugf.description": "file:D:/Workspace/Unity Game Framework/ugf-description/Packages/UGF.Description",
     "com.unity.ide.rider": "3.0.3",
     "com.unity.test-framework": "1.1.19"
   },

--- a/Packages/packages-lock.json
+++ b/Packages/packages-lock.json
@@ -64,14 +64,14 @@
       }
     },
     "com.unity.ext.nunit": {
-      "version": "1.0.0",
+      "version": "1.0.5",
       "depth": 1,
       "source": "registry",
       "dependencies": {},
       "url": "https://packages.unity.com"
     },
     "com.unity.ide.rider": {
-      "version": "2.0.7",
+      "version": "3.0.3",
       "depth": 0,
       "source": "registry",
       "dependencies": {
@@ -80,11 +80,11 @@
       "url": "https://packages.unity.com"
     },
     "com.unity.test-framework": {
-      "version": "1.1.18",
+      "version": "1.1.19",
       "depth": 0,
       "source": "registry",
       "dependencies": {
-        "com.unity.ext.nunit": "1.0.0",
+        "com.unity.ext.nunit": "1.0.5",
         "com.unity.modules.imgui": "1.0.0",
         "com.unity.modules.jsonserialize": "1.0.0"
       },

--- a/Packages/packages-lock.json
+++ b/Packages/packages-lock.json
@@ -1,24 +1,26 @@
 {
   "dependencies": {
     "com.ugf.application": {
-      "version": "file:D:/Workspace/Unity Game Framework/ugf-application/Packages/UGF.Application",
-      "depth": 0,
-      "source": "local",
+      "version": "6.0.0",
+      "depth": 1,
+      "source": "registry",
       "dependencies": {
         "com.ugf.initialize": "2.6.0",
-        "com.ugf.customsettings": "3.4.0",
-        "com.ugf.editortools": "1.7.0"
-      }
+        "com.ugf.description": "2.0.0",
+        "com.ugf.customsettings": "3.4.0"
+      },
+      "url": "https://api.bintray.com/npm/unity-game-framework/public"
     },
     "com.ugf.builder": {
-      "version": "file:D:/Workspace/Unity Game Framework/ugf-builder/Packages/UGF.Builder",
-      "depth": 0,
-      "source": "local",
-      "dependencies": {}
+      "version": "2.0.0",
+      "depth": 3,
+      "source": "registry",
+      "dependencies": {},
+      "url": "https://api.bintray.com/npm/unity-game-framework/public"
     },
     "com.ugf.customsettings": {
       "version": "3.4.0",
-      "depth": 1,
+      "depth": 2,
       "source": "registry",
       "dependencies": {
         "com.ugf.editortools": "1.7.0"
@@ -26,41 +28,43 @@
       "url": "https://api.bintray.com/npm/unity-game-framework/public"
     },
     "com.ugf.defines": {
-      "version": "2.0.0",
+      "version": "2.1.0",
       "depth": 2,
       "source": "registry",
       "dependencies": {
-        "com.ugf.customsettings": "3.1.0",
-        "com.ugf.editortools": "1.6.0"
+        "com.ugf.customsettings": "3.4.0"
       },
       "url": "https://api.bintray.com/npm/unity-game-framework/public"
     },
     "com.ugf.description": {
-      "version": "file:D:/Workspace/Unity Game Framework/ugf-description/Packages/UGF.Description",
-      "depth": 0,
-      "source": "local",
-      "dependencies": {}
+      "version": "2.0.0",
+      "depth": 2,
+      "source": "registry",
+      "dependencies": {
+        "com.ugf.builder": "2.0.0"
+      },
+      "url": "https://api.bintray.com/npm/unity-game-framework/public"
     },
     "com.ugf.editortools": {
       "version": "1.7.0",
-      "depth": 1,
+      "depth": 3,
       "source": "registry",
       "dependencies": {},
       "url": "https://api.bintray.com/npm/unity-game-framework/public"
     },
     "com.ugf.initialize": {
       "version": "2.6.0",
-      "depth": 1,
+      "depth": 2,
       "source": "registry",
       "dependencies": {},
       "url": "https://api.bintray.com/npm/unity-game-framework/public"
     },
     "com.ugf.logs": {
-      "version": "4.0.0",
+      "version": "4.1.0",
       "depth": 1,
       "source": "registry",
       "dependencies": {
-        "com.ugf.defines": "2.0.0"
+        "com.ugf.defines": "2.1.0"
       },
       "url": "https://api.bintray.com/npm/unity-game-framework/public"
     },
@@ -69,9 +73,8 @@
       "depth": 0,
       "source": "embedded",
       "dependencies": {
-        "com.ugf.application": "5.3.0",
-        "com.ugf.customsettings": "3.2.0",
-        "com.ugf.logs": "4.0.0"
+        "com.ugf.application": "6.0.0",
+        "com.ugf.logs": "4.1.0"
       }
     },
     "com.unity.ext.nunit": {

--- a/Packages/packages-lock.json
+++ b/Packages/packages-lock.json
@@ -1,22 +1,27 @@
 {
   "dependencies": {
     "com.ugf.application": {
-      "version": "5.3.0",
-      "depth": 1,
-      "source": "registry",
+      "version": "file:D:/Workspace/Unity Game Framework/ugf-application/Packages/UGF.Application",
+      "depth": 0,
+      "source": "local",
       "dependencies": {
-        "com.ugf.initialize": "2.4.0",
-        "com.ugf.customsettings": "3.0.1",
-        "com.ugf.editortools": "1.5.1"
-      },
-      "url": "https://api.bintray.com/npm/unity-game-framework/public"
+        "com.ugf.initialize": "2.6.0",
+        "com.ugf.customsettings": "3.4.0",
+        "com.ugf.editortools": "1.7.0"
+      }
+    },
+    "com.ugf.builder": {
+      "version": "file:D:/Workspace/Unity Game Framework/ugf-builder/Packages/UGF.Builder",
+      "depth": 0,
+      "source": "local",
+      "dependencies": {}
     },
     "com.ugf.customsettings": {
-      "version": "3.2.0",
+      "version": "3.4.0",
       "depth": 1,
       "source": "registry",
       "dependencies": {
-        "com.ugf.editortools": "1.6.0"
+        "com.ugf.editortools": "1.7.0"
       },
       "url": "https://api.bintray.com/npm/unity-game-framework/public"
     },
@@ -30,16 +35,22 @@
       },
       "url": "https://api.bintray.com/npm/unity-game-framework/public"
     },
+    "com.ugf.description": {
+      "version": "file:D:/Workspace/Unity Game Framework/ugf-description/Packages/UGF.Description",
+      "depth": 0,
+      "source": "local",
+      "dependencies": {}
+    },
     "com.ugf.editortools": {
-      "version": "1.6.0",
-      "depth": 2,
+      "version": "1.7.0",
+      "depth": 1,
       "source": "registry",
       "dependencies": {},
       "url": "https://api.bintray.com/npm/unity-game-framework/public"
     },
     "com.ugf.initialize": {
-      "version": "2.4.0",
-      "depth": 2,
+      "version": "2.6.0",
+      "depth": 1,
       "source": "registry",
       "dependencies": {},
       "url": "https://api.bintray.com/npm/unity-game-framework/public"

--- a/ProjectSettings/ProjectVersion.txt
+++ b/ProjectSettings/ProjectVersion.txt
@@ -1,2 +1,2 @@
-m_EditorVersion: 2020.2.0b9
-m_EditorVersionWithRevision: 2020.2.0b9 (ef2968fa77ae)
+m_EditorVersion: 2020.2.0b12
+m_EditorVersionWithRevision: 2020.2.0b12 (92852ae685d8)


### PR DESCRIPTION
- Update to use `UGF.Builder` and `UGF.Description` packages from the latest version of `UGF.Application` package.
- Add component menu name for `SceneContainer` component.
- Change dependencies: `com.ugf.application` to `6.0.0` and `com.ugf.logs` to `4.1.0`.
- Change all assets to use and implement builders features.
- Change name of the root of create asset menu, from `UGF` to `Unity Game Framework`.