### PR TITLE
Add support for application access by scene

### DIFF
--- a/Assets/UGF.Module.Scenes.Runtime.Tests/Resources/Module.asset
+++ b/Assets/UGF.Module.Scenes.Runtime.Tests/Resources/Module.asset
@@ -13,6 +13,7 @@ MonoBehaviour:
   m_Name: Module
   m_EditorClassIdentifier: 
   m_unloadTrackedScenesOnUninitialize: 1
+  m_registerApplicationForScenes: 1
   m_loaders:
   - m_guid: 9fadd5c60f34fee42acd011bc692d89b
     m_asset: {fileID: 11400000, guid: 9fadd5c60f34fee42acd011bc692d89b, type: 2}

--- a/Assets/UGF.Module.Scenes.Runtime.Tests/Resources/SceneTest.unity
+++ b/Assets/UGF.Module.Scenes.Runtime.Tests/Resources/SceneTest.unity
@@ -355,7 +355,7 @@ MonoBehaviour:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1604289255}
-  m_Enabled: 1
+  m_Enabled: 0
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 10dcef6a7dd24ce0a5655f16f3b4a1f8, type: 3}
   m_Name: 

--- a/Assets/UGF.Module.Scenes.Runtime.Tests/Resources/SceneTest.unity
+++ b/Assets/UGF.Module.Scenes.Runtime.Tests/Resources/SceneTest.unity
@@ -300,6 +300,8 @@ GameObject:
   m_Component:
   - component: {fileID: 1604289256}
   - component: {fileID: 1604289257}
+  - component: {fileID: 1604289258}
+  - component: {fileID: 1604289259}
   m_Layer: 0
   m_Name: Container
   m_TagString: Untagged
@@ -334,3 +336,28 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   m_containers: []
+--- !u!114 &1604289258
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1604289255}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 6d5b9d595f1346d3bca72005df2ce423, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &1604289259
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1604289255}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 10dcef6a7dd24ce0a5655f16f3b4a1f8, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_application: {fileID: 1604289258}

--- a/Assets/UGF.Module.Scenes.Runtime.Tests/TestSceneApplicationAccessComponent.cs
+++ b/Assets/UGF.Module.Scenes.Runtime.Tests/TestSceneApplicationAccessComponent.cs
@@ -7,12 +7,17 @@ namespace UGF.Module.Scenes.Runtime.Tests
     public class TestSceneApplicationAccessComponent : MonoBehaviour
     {
         [SerializeField] private ApplicationAccessComponent m_application;
+        [SerializeField] private bool m_checkOnAwake;
 
         public ApplicationAccessComponent Application { get { return m_application; } set { m_application = value; } }
+        public bool CheckOnAwake { get { return m_checkOnAwake; } set { m_checkOnAwake = value; } }
 
         private void Awake()
         {
-            Check();
+            if (m_checkOnAwake)
+            {
+                Check();
+            }
         }
 
         private void Start()

--- a/Assets/UGF.Module.Scenes.Runtime.Tests/TestSceneApplicationAccessComponent.cs
+++ b/Assets/UGF.Module.Scenes.Runtime.Tests/TestSceneApplicationAccessComponent.cs
@@ -1,0 +1,35 @@
+﻿using NUnit.Framework;
+using UGF.Application.Runtime;
+using UnityEngine;
+
+namespace UGF.Module.Scenes.Runtime.Tests
+{
+    public class TestSceneApplicationAccessComponent : MonoBehaviour
+    {
+        [SerializeField] private ApplicationAccessComponent m_application;
+
+        public ApplicationAccessComponent Application { get { return m_application; } set { m_application = value; } }
+
+        private void Awake()
+        {
+            Check();
+        }
+
+        private void Start()
+        {
+            Check();
+        }
+
+        private void OnEnable()
+        {
+            Check();
+        }
+
+        private void Check()
+        {
+            IApplication application = m_application.GetApplication();
+
+            Assert.NotNull(application);
+        }
+    }
+}

--- a/Assets/UGF.Module.Scenes.Runtime.Tests/TestSceneApplicationAccessComponent.cs.meta
+++ b/Assets/UGF.Module.Scenes.Runtime.Tests/TestSceneApplicationAccessComponent.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 10dcef6a7dd24ce0a5655f16f3b4a1f8
+timeCreated: 1608057772

--- a/Assets/UGF.Module.Scenes.Runtime.Tests/TestSceneModule.cs
+++ b/Assets/UGF.Module.Scenes.Runtime.Tests/TestSceneModule.cs
@@ -1,8 +1,10 @@
 ﻿using System.Collections;
+using System.Linq;
 using System.Threading.Tasks;
 using JetBrains.Annotations;
 using NUnit.Framework;
 using UGF.Application.Runtime;
+using UGF.Application.Runtime.Scenes;
 using UnityEngine;
 using UnityEngine.SceneManagement;
 using UnityEngine.TestTools;
@@ -15,6 +17,7 @@ namespace UGF.Module.Scenes.Runtime.Tests
         public IEnumerator Teardown()
         {
             SceneManager.LoadScene("SampleScene", new LoadSceneParameters(LoadSceneMode.Single));
+            ApplicationSceneProviderInstance.Provider.Clear();
 
             yield return null;
         }
@@ -31,15 +34,24 @@ namespace UGF.Module.Scenes.Runtime.Tests
             var module = application.GetModule<ISceneModule>();
             Scene scene = module.Load(id, SceneLoadParameters.DefaultAdditive);
 
+            Assert.Contains(scene, module.Scenes.Keys.ToArray());
+            Assert.Contains(scene, ApplicationSceneProviderInstance.Provider.Applications.Keys.ToArray());
+            Assert.Contains(application, ApplicationSceneProviderInstance.Provider.Applications.Values.ToArray());
+
             yield return null;
 
             Assert.True(scene.IsValid(), "Load: scene.IsValid()");
             Assert.True(scene.isLoaded, "Load: scene.isLoaded");
             Assert.AreEqual(module.Provider.GetScene(id).Address, "d39a9027b65879843ab7fc2c1a4a22af");
+            Assert.Contains(scene, module.Scenes.Keys.ToArray());
 
             if (unload)
             {
                 module.Unload(id, scene, SceneUnloadParameters.Default);
+
+                Assert.IsEmpty(module.Scenes.Keys);
+                Assert.IsEmpty(ApplicationSceneProviderInstance.Provider.Applications.Keys);
+                Assert.IsEmpty(ApplicationSceneProviderInstance.Provider.Applications.Values);
 
                 yield return null;
 
@@ -67,6 +79,10 @@ namespace UGF.Module.Scenes.Runtime.Tests
 
             Scene scene = task.Result;
 
+            Assert.Contains(scene, module.Scenes.Keys.ToArray());
+            Assert.Contains(task.Result, ApplicationSceneProviderInstance.Provider.Applications.Keys.ToArray());
+            Assert.Contains(application, ApplicationSceneProviderInstance.Provider.Applications.Values.ToArray());
+
             Assert.True(scene.IsValid(), "Load: scene.IsValid()");
             Assert.True(scene.isLoaded, "Load: scene.isLoaded");
             Assert.AreEqual(module.Provider.GetScene(id).Address, "d39a9027b65879843ab7fc2c1a4a22af");
@@ -79,6 +95,10 @@ namespace UGF.Module.Scenes.Runtime.Tests
                 {
                     yield return null;
                 }
+
+                Assert.IsEmpty(module.Scenes.Keys);
+                Assert.IsEmpty(ApplicationSceneProviderInstance.Provider.Applications.Keys);
+                Assert.IsEmpty(ApplicationSceneProviderInstance.Provider.Applications.Values);
 
                 Assert.False(scene.IsValid(), "Unload: scene.IsValid()");
                 Assert.False(scene.isLoaded, "Unload: scene.isLoaded");

--- a/Packages/UGF.Module.Scenes/Editor/SceneModuleAssetEditor.cs
+++ b/Packages/UGF.Module.Scenes/Editor/SceneModuleAssetEditor.cs
@@ -10,6 +10,7 @@ namespace UGF.Module.Scenes.Editor
     {
         private SerializedProperty m_propertyScript;
         private SerializedProperty m_propertyUnloadTrackedScenesOnUninitialize;
+        private SerializedProperty m_propertyRegisterApplicationForScenes;
         private AssetReferenceListDrawer m_listLoaders;
         private AssetReferenceListDrawer m_listScenes;
 
@@ -17,6 +18,7 @@ namespace UGF.Module.Scenes.Editor
         {
             m_propertyScript = serializedObject.FindProperty("m_Script");
             m_propertyUnloadTrackedScenesOnUninitialize = serializedObject.FindProperty("m_unloadTrackedScenesOnUninitialize");
+            m_propertyRegisterApplicationForScenes = serializedObject.FindProperty("m_registerApplicationForScenes");
 
             m_listLoaders = new AssetReferenceListDrawer(serializedObject.FindProperty("m_loaders"));
             m_listScenes = new AssetReferenceListDrawer(serializedObject.FindProperty("m_scenes"));
@@ -41,6 +43,7 @@ namespace UGF.Module.Scenes.Editor
                 }
 
                 EditorGUILayout.PropertyField(m_propertyUnloadTrackedScenesOnUninitialize);
+                EditorGUILayout.PropertyField(m_propertyRegisterApplicationForScenes);
 
                 m_listLoaders.DrawGUILayout();
                 m_listScenes.DrawGUILayout();

--- a/Packages/UGF.Module.Scenes/Runtime/ISceneModule.cs
+++ b/Packages/UGF.Module.Scenes/Runtime/ISceneModule.cs
@@ -21,6 +21,6 @@ namespace UGF.Module.Scenes.Runtime
         void Unload(string id, Scene scene, SceneUnloadParameters parameters);
         Task UnloadAsync(string id, Scene scene, SceneUnloadParameters parameters);
         SceneInstance GetScene(Scene scene);
-        bool TryGetScene(Scene scene, out SceneInstance controller);
+        bool TryGetScene(Scene scene, out SceneInstance instance);
     }
 }

--- a/Packages/UGF.Module.Scenes/Runtime/SceneModule.cs
+++ b/Packages/UGF.Module.Scenes/Runtime/SceneModule.cs
@@ -4,6 +4,7 @@ using System.Collections.ObjectModel;
 using System.Linq;
 using System.Threading.Tasks;
 using UGF.Application.Runtime;
+using UGF.Application.Runtime.Scenes;
 using UGF.Logs.Runtime;
 using UnityEngine.SceneManagement;
 
@@ -174,11 +175,20 @@ namespace UGF.Module.Scenes.Runtime
 
         protected virtual SceneInstance OnAddScene(string id, Scene scene, SceneLoadParameters parameters)
         {
+            if (Description.RegisterApplicationForScenes)
+            {
+                ApplicationSceneProviderInstance.Provider.Add(scene, Application);
+            }
+
             return new SceneInstance(scene, id);
         }
 
         protected virtual void OnRemoveScene(string id, Scene scene, SceneUnloadParameters parameters)
         {
+            if (Description.RegisterApplicationForScenes)
+            {
+                ApplicationSceneProviderInstance.Provider.Remove(scene);
+            }
         }
 
         protected virtual Scene OnLoad(string id, SceneLoadParameters parameters)

--- a/Packages/UGF.Module.Scenes/Runtime/SceneModule.cs
+++ b/Packages/UGF.Module.Scenes/Runtime/SceneModule.cs
@@ -13,6 +13,7 @@ namespace UGF.Module.Scenes.Runtime
     public partial class SceneModule : ApplicationModule<SceneModuleDescription>, ISceneModule
     {
         public ISceneProvider Provider { get; }
+        public IApplicationSceneProvider ApplicationSceneProvider { get; }
         public IReadOnlyDictionary<Scene, SceneInstance> Scenes { get; }
 
         ISceneModuleDescription ISceneModule.Description { get { return Description; } }
@@ -24,13 +25,14 @@ namespace UGF.Module.Scenes.Runtime
 
         private readonly Dictionary<Scene, SceneInstance> m_scenes = new Dictionary<Scene, SceneInstance>();
 
-        public SceneModule(SceneModuleDescription description, IApplication application) : this(description, application, new SceneProvider())
+        public SceneModule(SceneModuleDescription description, IApplication application) : this(description, application, new SceneProvider(), ApplicationSceneProviderInstance.Provider)
         {
         }
 
-        public SceneModule(SceneModuleDescription description, IApplication application, ISceneProvider provider) : base(description, application)
+        public SceneModule(SceneModuleDescription description, IApplication application, ISceneProvider provider, IApplicationSceneProvider applicationSceneProvider) : base(description, application)
         {
             Provider = provider ?? throw new ArgumentNullException(nameof(provider));
+            ApplicationSceneProvider = applicationSceneProvider ?? throw new ArgumentNullException(nameof(applicationSceneProvider));
             Scenes = new ReadOnlyDictionary<Scene, SceneInstance>(m_scenes);
         }
 
@@ -168,16 +170,16 @@ namespace UGF.Module.Scenes.Runtime
             return TryGetScene(scene, out SceneInstance instance) ? instance : throw new ArgumentException($"Scene instance not found by the specified scene: '{scene.name}'.");
         }
 
-        public bool TryGetScene(Scene scene, out SceneInstance controller)
+        public bool TryGetScene(Scene scene, out SceneInstance instance)
         {
-            return m_scenes.TryGetValue(scene, out controller);
+            return m_scenes.TryGetValue(scene, out instance);
         }
 
         protected virtual SceneInstance OnAddScene(string id, Scene scene, SceneLoadParameters parameters)
         {
             if (Description.RegisterApplicationForScenes)
             {
-                ApplicationSceneProviderInstance.Provider.Add(scene, Application);
+                ApplicationSceneProvider.Add(scene, Application);
             }
 
             return new SceneInstance(scene, id);
@@ -187,7 +189,7 @@ namespace UGF.Module.Scenes.Runtime
         {
             if (Description.RegisterApplicationForScenes)
             {
-                ApplicationSceneProviderInstance.Provider.Remove(scene);
+                ApplicationSceneProvider.Remove(scene);
             }
         }
 

--- a/Packages/UGF.Module.Scenes/Runtime/SceneModuleAsset.cs
+++ b/Packages/UGF.Module.Scenes/Runtime/SceneModuleAsset.cs
@@ -9,10 +9,12 @@ namespace UGF.Module.Scenes.Runtime
     public class SceneModuleAsset : ApplicationModuleAsset<ISceneModule, SceneModuleDescription>
     {
         [SerializeField] private bool m_unloadTrackedScenesOnUninitialize = true;
+        [SerializeField] private bool m_registerApplicationForScenes = true;
         [SerializeField] private List<AssetReference<SceneLoaderAssetBase>> m_loaders = new List<AssetReference<SceneLoaderAssetBase>>();
         [SerializeField] private List<AssetReference<SceneInfoAssetBase>> m_scenes = new List<AssetReference<SceneInfoAssetBase>>();
 
         public bool UnloadTrackedScenesOnUninitialize { get { return m_unloadTrackedScenesOnUninitialize; } set { m_unloadTrackedScenesOnUninitialize = value; } }
+        public bool RegisterApplicationForScenes { get { return m_registerApplicationForScenes; } set { m_registerApplicationForScenes = value; } }
         public List<AssetReference<SceneLoaderAssetBase>> Loaders { get { return m_loaders; } }
         public List<AssetReference<SceneInfoAssetBase>> Scenes { get { return m_scenes; } }
 
@@ -20,7 +22,8 @@ namespace UGF.Module.Scenes.Runtime
         {
             var description = new SceneModuleDescription(typeof(ISceneModule))
             {
-                UnloadTrackedScenesOnUninitialize = m_unloadTrackedScenesOnUninitialize
+                UnloadTrackedScenesOnUninitialize = m_unloadTrackedScenesOnUninitialize,
+                RegisterApplicationForScenes = m_registerApplicationForScenes
             };
 
             for (int i = 0; i < m_loaders.Count; i++)

--- a/Packages/UGF.Module.Scenes/Runtime/SceneModuleDescription.cs
+++ b/Packages/UGF.Module.Scenes/Runtime/SceneModuleDescription.cs
@@ -9,6 +9,7 @@ namespace UGF.Module.Scenes.Runtime
         public Dictionary<string, ISceneLoader> Loaders { get; } = new Dictionary<string, ISceneLoader>();
         public Dictionary<string, ISceneInfo> Scenes { get; } = new Dictionary<string, ISceneInfo>();
         public bool UnloadTrackedScenesOnUninitialize { get; set; } = true;
+        public bool RegisterApplicationForScenes { get; set; } = true;
 
         IReadOnlyDictionary<string, ISceneLoader> ISceneModuleDescription.Loaders { get { return Loaders; } }
         IReadOnlyDictionary<string, ISceneInfo> ISceneModuleDescription.Scenes { get { return Scenes; } }

--- a/Packages/UGF.Module.Scenes/package.json
+++ b/Packages/UGF.Module.Scenes/package.json
@@ -22,7 +22,7 @@
     "registry": "https://api.bintray.com/content/unity-game-framework/public"
   },
   "dependencies": {
-    "com.ugf.application": "6.0.0",
+    "com.ugf.application": "6.1.0",
     "com.ugf.logs": "4.1.0"
   }
 }

--- a/Packages/manifest.json
+++ b/Packages/manifest.json
@@ -1,6 +1,5 @@
 {
   "dependencies": {
-    "com.ugf.application": "file:../../ugf-application/Packages/UGF.Application",
     "com.unity.ide.rider": "3.0.3",
     "com.unity.test-framework": "1.1.19"
   },

--- a/Packages/manifest.json
+++ b/Packages/manifest.json
@@ -1,5 +1,6 @@
 {
   "dependencies": {
+    "com.ugf.application": "file:../../ugf-application/Packages/UGF.Application",
     "com.unity.ide.rider": "3.0.3",
     "com.unity.test-framework": "1.1.19"
   },

--- a/Packages/packages-lock.json
+++ b/Packages/packages-lock.json
@@ -1,26 +1,25 @@
 {
   "dependencies": {
     "com.ugf.application": {
-      "version": "6.0.0",
-      "depth": 1,
-      "source": "registry",
+      "version": "file:../../ugf-application/Packages/UGF.Application",
+      "depth": 0,
+      "source": "local",
       "dependencies": {
         "com.ugf.initialize": "2.6.0",
         "com.ugf.description": "2.0.0",
         "com.ugf.customsettings": "3.4.0"
-      },
-      "url": "https://api.bintray.com/npm/unity-game-framework/public"
+      }
     },
     "com.ugf.builder": {
       "version": "2.0.0",
-      "depth": 3,
+      "depth": 2,
       "source": "registry",
       "dependencies": {},
       "url": "https://api.bintray.com/npm/unity-game-framework/public"
     },
     "com.ugf.customsettings": {
       "version": "3.4.0",
-      "depth": 2,
+      "depth": 1,
       "source": "registry",
       "dependencies": {
         "com.ugf.editortools": "1.7.0"
@@ -38,7 +37,7 @@
     },
     "com.ugf.description": {
       "version": "2.0.0",
-      "depth": 2,
+      "depth": 1,
       "source": "registry",
       "dependencies": {
         "com.ugf.builder": "2.0.0"
@@ -47,14 +46,14 @@
     },
     "com.ugf.editortools": {
       "version": "1.7.0",
-      "depth": 3,
+      "depth": 2,
       "source": "registry",
       "dependencies": {},
       "url": "https://api.bintray.com/npm/unity-game-framework/public"
     },
     "com.ugf.initialize": {
       "version": "2.6.0",
-      "depth": 2,
+      "depth": 1,
       "source": "registry",
       "dependencies": {},
       "url": "https://api.bintray.com/npm/unity-game-framework/public"

--- a/Packages/packages-lock.json
+++ b/Packages/packages-lock.json
@@ -1,25 +1,26 @@
 {
   "dependencies": {
     "com.ugf.application": {
-      "version": "file:../../ugf-application/Packages/UGF.Application",
-      "depth": 0,
-      "source": "local",
+      "version": "6.1.0",
+      "depth": 1,
+      "source": "registry",
       "dependencies": {
         "com.ugf.initialize": "2.6.0",
         "com.ugf.description": "2.0.0",
         "com.ugf.customsettings": "3.4.0"
-      }
+      },
+      "url": "https://api.bintray.com/npm/unity-game-framework/public"
     },
     "com.ugf.builder": {
       "version": "2.0.0",
-      "depth": 2,
+      "depth": 3,
       "source": "registry",
       "dependencies": {},
       "url": "https://api.bintray.com/npm/unity-game-framework/public"
     },
     "com.ugf.customsettings": {
       "version": "3.4.0",
-      "depth": 1,
+      "depth": 2,
       "source": "registry",
       "dependencies": {
         "com.ugf.editortools": "1.7.0"
@@ -37,7 +38,7 @@
     },
     "com.ugf.description": {
       "version": "2.0.0",
-      "depth": 1,
+      "depth": 2,
       "source": "registry",
       "dependencies": {
         "com.ugf.builder": "2.0.0"
@@ -46,14 +47,14 @@
     },
     "com.ugf.editortools": {
       "version": "1.7.0",
-      "depth": 2,
+      "depth": 3,
       "source": "registry",
       "dependencies": {},
       "url": "https://api.bintray.com/npm/unity-game-framework/public"
     },
     "com.ugf.initialize": {
       "version": "2.6.0",
-      "depth": 1,
+      "depth": 2,
       "source": "registry",
       "dependencies": {},
       "url": "https://api.bintray.com/npm/unity-game-framework/public"
@@ -72,7 +73,7 @@
       "depth": 0,
       "source": "embedded",
       "dependencies": {
-        "com.ugf.application": "6.0.0",
+        "com.ugf.application": "6.1.0",
         "com.ugf.logs": "4.1.0"
       }
     },

--- a/ProjectSettings/ProjectVersion.txt
+++ b/ProjectSettings/ProjectVersion.txt
@@ -1,2 +1,2 @@
-m_EditorVersion: 2020.2.0b12
-m_EditorVersionWithRevision: 2020.2.0b12 (92852ae685d8)
+m_EditorVersion: 2020.2.0f1
+m_EditorVersionWithRevision: 2020.2.0f1 (3721df5a8b28)


### PR DESCRIPTION
- Add `SceneModule.ApplicationSceneProvider` used to register application for loaded scenes.
- Add `SceneModuleDescription.RegisterApplicationForScenes` and `SceneModuleAsset.RegisterApplicationForScenes` properties to determine whether to register application for loaded scenes.
- Change dependencies: `com.ugf.application` to `6.1.0` version.