### PR TITLE
Load scene with delayed activation

### DIFF
--- a/Packages/UGF.Module.Scenes/Runtime/ISceneProvider.cs
+++ b/Packages/UGF.Module.Scenes/Runtime/ISceneProvider.cs
@@ -1,9 +1,11 @@
 ﻿using System.Collections.Generic;
+using UGF.Module.Scenes.Runtime.Operations;
 
 namespace UGF.Module.Scenes.Runtime
 {
     public interface ISceneProvider
     {
+        ISceneOperationProvider OperationProvider { get; }
         IReadOnlyDictionary<string, ISceneLoader> Loaders { get; }
         IReadOnlyDictionary<string, ISceneInfo> Scenes { get; }
 

--- a/Packages/UGF.Module.Scenes/Runtime/Loaders.Manager/ManagerSceneLoader.Logs.cs
+++ b/Packages/UGF.Module.Scenes/Runtime/Loaders.Manager/ManagerSceneLoader.Logs.cs
@@ -21,7 +21,8 @@ namespace UGF.Module.Scenes.Runtime.Loaders.Manager
                 parameters = new
                 {
                     parameters.AddMode,
-                    parameters.PhysicsMode
+                    parameters.PhysicsMode,
+                    parameters.AllowActivation
                 },
                 isAsync
             });
@@ -42,7 +43,8 @@ namespace UGF.Module.Scenes.Runtime.Loaders.Manager
                 parameters = new
                 {
                     parameters.AddMode,
-                    parameters.PhysicsMode
+                    parameters.PhysicsMode,
+                    parameters.AllowActivation
                 },
                 scene = new
                 {

--- a/Packages/UGF.Module.Scenes/Runtime/Loaders.Manager/ManagerSceneLoader.cs
+++ b/Packages/UGF.Module.Scenes/Runtime/Loaders.Manager/ManagerSceneLoader.cs
@@ -37,9 +37,24 @@ namespace UGF.Module.Scenes.Runtime.Loaders.Manager
             AsyncOperation operation = SceneManager.LoadSceneAsync(scenePath, options);
             Scene scene = SceneManager.GetSceneAt(SceneManager.sceneCount - 1);
 
-            while (!operation.isDone)
+            operation.allowSceneActivation = parameters.AllowActivation;
+            provider.OperationProvider.Add(scene, operation);
+
+            if (operation.allowSceneActivation)
             {
-                await Task.Yield();
+                while (!operation.isDone)
+                {
+                    await Task.Yield();
+                }
+
+                provider.OperationProvider.Remove(scene);
+            }
+            else
+            {
+                while (operation.progress < 0.9F)
+                {
+                    await Task.Yield();
+                }
             }
 
             LogSceneLoaded(id, info, parameters, scene, true);

--- a/Packages/UGF.Module.Scenes/Runtime/Operations.meta
+++ b/Packages/UGF.Module.Scenes/Runtime/Operations.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: f6d6e64c36724eb7a37a10a97284f428
+timeCreated: 1608060537

--- a/Packages/UGF.Module.Scenes/Runtime/Operations/ISceneOperationProvider.cs
+++ b/Packages/UGF.Module.Scenes/Runtime/Operations/ISceneOperationProvider.cs
@@ -1,0 +1,22 @@
+﻿using System;
+using System.Collections.Generic;
+using UnityEngine;
+using UnityEngine.SceneManagement;
+
+namespace UGF.Module.Scenes.Runtime.Operations
+{
+    public interface ISceneOperationProvider
+    {
+        IReadOnlyDictionary<Scene, AsyncOperation> Operations { get; }
+
+        event SceneOperationHandler Added;
+        event SceneOperationHandler Removed;
+        event Action Cleared;
+
+        void Add(Scene scene, AsyncOperation operation);
+        bool Remove(Scene scene);
+        void Clear();
+        AsyncOperation Get(Scene scene);
+        bool TryGet(Scene scene, out AsyncOperation operation);
+    }
+}

--- a/Packages/UGF.Module.Scenes/Runtime/Operations/ISceneOperationProvider.cs.meta
+++ b/Packages/UGF.Module.Scenes/Runtime/Operations/ISceneOperationProvider.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 6f70d1bcd7b84e9bbe2be85d1fe1202d
+timeCreated: 1608060514

--- a/Packages/UGF.Module.Scenes/Runtime/Operations/SceneExtensions.cs
+++ b/Packages/UGF.Module.Scenes/Runtime/Operations/SceneExtensions.cs
@@ -5,11 +5,17 @@ namespace UGF.Module.Scenes.Runtime.Operations
 {
     public static class SceneExtensions
     {
-        public static void Activate(this Scene scene)
+        public static void Activate(this Scene scene, bool clearOperation = true)
         {
-            AsyncOperation operation = SceneOperationProviderInstance.Provider.Get(scene);
+            ISceneOperationProvider provider = SceneOperationProviderInstance.Provider;
+            AsyncOperation operation = provider.Get(scene);
 
             operation.allowSceneActivation = true;
+
+            if (clearOperation)
+            {
+                provider.Remove(scene);
+            }
         }
 
         public static AsyncOperation GetOperation(this Scene scene)

--- a/Packages/UGF.Module.Scenes/Runtime/Operations/SceneExtensions.cs
+++ b/Packages/UGF.Module.Scenes/Runtime/Operations/SceneExtensions.cs
@@ -1,0 +1,25 @@
+﻿using UnityEngine;
+using UnityEngine.SceneManagement;
+
+namespace UGF.Module.Scenes.Runtime.Operations
+{
+    public static class SceneExtensions
+    {
+        public static void Activate(this Scene scene)
+        {
+            AsyncOperation operation = SceneOperationProviderInstance.Provider.Get(scene);
+
+            operation.allowSceneActivation = true;
+        }
+
+        public static AsyncOperation GetOperation(this Scene scene)
+        {
+            return SceneOperationProviderInstance.Provider.Get(scene);
+        }
+
+        public static bool TryGetOperation(this Scene scene, out AsyncOperation operation)
+        {
+            return SceneOperationProviderInstance.Provider.TryGet(scene, out operation);
+        }
+    }
+}

--- a/Packages/UGF.Module.Scenes/Runtime/Operations/SceneExtensions.cs.meta
+++ b/Packages/UGF.Module.Scenes/Runtime/Operations/SceneExtensions.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 01f3e93c502347a1ab422c113c047544
+timeCreated: 1608060443

--- a/Packages/UGF.Module.Scenes/Runtime/Operations/SceneOperationHandler.cs
+++ b/Packages/UGF.Module.Scenes/Runtime/Operations/SceneOperationHandler.cs
@@ -1,0 +1,7 @@
+﻿using UnityEngine;
+using UnityEngine.SceneManagement;
+
+namespace UGF.Module.Scenes.Runtime.Operations
+{
+    public delegate void SceneOperationHandler(Scene scene, AsyncOperation operation);
+}

--- a/Packages/UGF.Module.Scenes/Runtime/Operations/SceneOperationHandler.cs.meta
+++ b/Packages/UGF.Module.Scenes/Runtime/Operations/SceneOperationHandler.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 2d3ff9f3a9354ca1a938e5e42c26c858
+timeCreated: 1608060775

--- a/Packages/UGF.Module.Scenes/Runtime/Operations/SceneOperationProvider.cs
+++ b/Packages/UGF.Module.Scenes/Runtime/Operations/SceneOperationProvider.cs
@@ -1,0 +1,68 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using UnityEngine;
+using UnityEngine.SceneManagement;
+
+namespace UGF.Module.Scenes.Runtime.Operations
+{
+    public class SceneOperationProvider : ISceneOperationProvider
+    {
+        public IReadOnlyDictionary<Scene, AsyncOperation> Operations { get; }
+
+        public event SceneOperationHandler Added;
+        public event SceneOperationHandler Removed;
+        public event Action Cleared;
+
+        private readonly Dictionary<Scene, AsyncOperation> m_operations = new Dictionary<Scene, AsyncOperation>();
+
+        public SceneOperationProvider()
+        {
+            Operations = new ReadOnlyDictionary<Scene, AsyncOperation>(m_operations);
+        }
+
+        public void Add(Scene scene, AsyncOperation operation)
+        {
+            if (!scene.IsValid()) throw new ArgumentException("Value should be valid.", nameof(scene));
+            if (operation == null) throw new ArgumentNullException(nameof(operation));
+
+            m_operations.Add(scene, operation);
+
+            Added?.Invoke(scene, operation);
+        }
+
+        public bool Remove(Scene scene)
+        {
+            if (!scene.IsValid()) throw new ArgumentException("Value should be valid.", nameof(scene));
+
+            if (TryGet(scene, out AsyncOperation operation))
+            {
+                m_operations.Remove(scene);
+
+                Removed?.Invoke(scene, operation);
+                return true;
+            }
+
+            return false;
+        }
+
+        public void Clear()
+        {
+            m_operations.Clear();
+
+            Cleared?.Invoke();
+        }
+
+        public AsyncOperation Get(Scene scene)
+        {
+            return TryGet(scene, out AsyncOperation operation) ? operation : throw new ArgumentException($"Scene operation not found by the specified scene: '{scene.name}'.");
+        }
+
+        public bool TryGet(Scene scene, out AsyncOperation operation)
+        {
+            if (!scene.IsValid()) throw new ArgumentException("Value should be valid.", nameof(scene));
+
+            return m_operations.TryGetValue(scene, out operation);
+        }
+    }
+}

--- a/Packages/UGF.Module.Scenes/Runtime/Operations/SceneOperationProvider.cs.meta
+++ b/Packages/UGF.Module.Scenes/Runtime/Operations/SceneOperationProvider.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 05c0ca56e51b492da177b821bbdf1447
+timeCreated: 1608060602

--- a/Packages/UGF.Module.Scenes/Runtime/Operations/SceneOperationProviderInstance.cs
+++ b/Packages/UGF.Module.Scenes/Runtime/Operations/SceneOperationProviderInstance.cs
@@ -1,0 +1,11 @@
+﻿using System;
+
+namespace UGF.Module.Scenes.Runtime.Operations
+{
+    public static class SceneOperationProviderInstance
+    {
+        public static ISceneOperationProvider Provider { get { return m_provider; } set { m_provider = value ?? throw new ArgumentNullException(nameof(value)); } }
+
+        private static ISceneOperationProvider m_provider = new SceneOperationProvider();
+    }
+}

--- a/Packages/UGF.Module.Scenes/Runtime/Operations/SceneOperationProviderInstance.cs.meta
+++ b/Packages/UGF.Module.Scenes/Runtime/Operations/SceneOperationProviderInstance.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 65f6fb60985f4bb9b2ac71ad5b3a879a
+timeCreated: 1608061102

--- a/Packages/UGF.Module.Scenes/Runtime/SceneLoadParameters.cs
+++ b/Packages/UGF.Module.Scenes/Runtime/SceneLoadParameters.cs
@@ -9,17 +9,21 @@ namespace UGF.Module.Scenes.Runtime
     {
         [SerializeField] private LoadSceneMode m_addMode;
         [SerializeField] private LocalPhysicsMode m_physicsMode;
+        [SerializeField] private bool m_allowActivation;
 
         public LoadSceneMode AddMode { get { return m_addMode; } set { m_addMode = value; } }
         public LocalPhysicsMode PhysicsMode { get { return m_physicsMode; } set { m_physicsMode = value; } }
+        public bool AllowActivation { get { return m_allowActivation; } set { m_allowActivation = value; } }
 
         public static SceneLoadParameters Default { get; } = new SceneLoadParameters(LoadSceneMode.Single, LocalPhysicsMode.None);
         public static SceneLoadParameters DefaultAdditive { get; } = new SceneLoadParameters(LoadSceneMode.Additive, LocalPhysicsMode.None);
+        public static SceneLoadParameters DefaultAdditiveDisabled { get; } = new SceneLoadParameters(LoadSceneMode.Additive, LocalPhysicsMode.None, false);
 
-        public SceneLoadParameters(LoadSceneMode addMode, LocalPhysicsMode physicsMode)
+        public SceneLoadParameters(LoadSceneMode addMode, LocalPhysicsMode physicsMode, bool allowActivation = true)
         {
             m_addMode = addMode;
             m_physicsMode = physicsMode;
+            m_allowActivation = allowActivation;
         }
     }
 }

--- a/Packages/UGF.Module.Scenes/Runtime/SceneModule.Logs.cs
+++ b/Packages/UGF.Module.Scenes/Runtime/SceneModule.Logs.cs
@@ -16,7 +16,8 @@ namespace UGF.Module.Scenes.Runtime
                 parameters = new
                 {
                     parameters.AddMode,
-                    parameters.PhysicsMode
+                    parameters.PhysicsMode,
+                    parameters.AllowActivation
                 },
                 isAsync
             });
@@ -41,7 +42,8 @@ namespace UGF.Module.Scenes.Runtime
                 parameters = new
                 {
                     parameters.AddMode,
-                    parameters.PhysicsMode
+                    parameters.PhysicsMode,
+                    parameters.AllowActivation
                 },
                 isAsync
             });

--- a/Packages/UGF.Module.Scenes/Runtime/SceneProvider.cs
+++ b/Packages/UGF.Module.Scenes/Runtime/SceneProvider.cs
@@ -1,19 +1,26 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
+using UGF.Module.Scenes.Runtime.Operations;
 
 namespace UGF.Module.Scenes.Runtime
 {
     public class SceneProvider : ISceneProvider
     {
+        public ISceneOperationProvider OperationProvider { get; }
         public IReadOnlyDictionary<string, ISceneLoader> Loaders { get; }
         public IReadOnlyDictionary<string, ISceneInfo> Scenes { get; }
 
         private readonly Dictionary<string, ISceneLoader> m_loaders = new Dictionary<string, ISceneLoader>();
         private readonly Dictionary<string, ISceneInfo> m_scenes = new Dictionary<string, ISceneInfo>();
 
-        public SceneProvider()
+        public SceneProvider() : this(SceneOperationProviderInstance.Provider)
         {
+        }
+
+        public SceneProvider(ISceneOperationProvider operationProvider)
+        {
+            OperationProvider = operationProvider ?? throw new ArgumentNullException(nameof(operationProvider));
             Loaders = new ReadOnlyDictionary<string, ISceneLoader>(m_loaders);
             Scenes = new ReadOnlyDictionary<string, ISceneInfo>(m_scenes);
         }


### PR DESCRIPTION
- Add `ISceneOperationProvider` with default implementation `SceneOperationProvider ` to store `AsyncOperation` for specific scene.
- Add `SceneOperationProviderInstance` as static access to global scene operation provider instance.
- Add `Activate`, `GetOperation` and `TryGetOperation` extensions method for scene.
- Add `SceneLoadParameters.AllowActivation` property to determine whether to activate scene after loading.
- Change `ManagerSceneLoader` to support delayed scene activation using `SceneLoadParameters.AllowActivation` parameter.
- Change `ManagerSceneLoader` to support and manage scene operations.