### PR TITLE
Add scene info load and unload default parameters

### DIFF
--- a/Assets/UGF.Module.Scenes.Runtime.Tests/New Manager Scene Loader Asset.asset
+++ b/Assets/UGF.Module.Scenes.Runtime.Tests/New Manager Scene Loader Asset.asset
@@ -13,3 +13,9 @@ MonoBehaviour:
   m_Name: New Manager Scene Loader Asset
   m_EditorClassIdentifier: 
   m_unloadUnusedAfterUnload: 0
+  m_defaultLoadParameters:
+    m_addMode: 0
+    m_physicsMode: 0
+    m_allowActivation: 1
+  m_defaultUnloadParameters:
+    m_options: 1

--- a/Assets/UGF.Module.Scenes.Runtime.Tests/Resources/Group2.asset
+++ b/Assets/UGF.Module.Scenes.Runtime.Tests/Resources/Group2.asset
@@ -9,13 +9,10 @@ MonoBehaviour:
   m_GameObject: {fileID: 0}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 869877dcdceb4129bbea1fa939c7b71b, type: 3}
-  m_Name: Loader
+  m_Script: {fileID: 11500000, guid: a527a59f18494c809bf69f37cfcc66b3, type: 3}
+  m_Name: Group2
   m_EditorClassIdentifier: 
-  m_unloadUnusedAfterUnload: 0
-  m_defaultLoadParameters:
-    m_addMode: 1
-    m_physicsMode: 0
-    m_allowActivation: 1
-  m_defaultUnloadParameters:
-    m_options: 1
+  m_loader: 600ff64afcd85df4cb980b92cba88dda
+  m_scenes:
+  - m_id: d39a9027b65879843ab7fc2c1a4a22af
+    m_address: Assets/UGF.Module.Scenes.Runtime.Tests/Resources/SceneTest.unity

--- a/Assets/UGF.Module.Scenes.Runtime.Tests/Resources/Group2.asset.meta
+++ b/Assets/UGF.Module.Scenes.Runtime.Tests/Resources/Group2.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: b7a8683c9bcfb87478c5fc09d50e12ca
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/UGF.Module.Scenes.Runtime.Tests/Resources/Loader.asset
+++ b/Assets/UGF.Module.Scenes.Runtime.Tests/Resources/Loader.asset
@@ -13,3 +13,9 @@ MonoBehaviour:
   m_Name: Loader
   m_EditorClassIdentifier: 
   m_unloadUnusedAfterUnload: 0
+  m_defaultLoadParameters:
+    m_addMode: 0
+    m_physicsMode: 0
+    m_allowActivation: 1
+  m_defaultUnloadParameters:
+    m_options: 1

--- a/Assets/UGF.Module.Scenes.Runtime.Tests/Resources/Loader2.asset
+++ b/Assets/UGF.Module.Scenes.Runtime.Tests/Resources/Loader2.asset
@@ -10,12 +10,12 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 869877dcdceb4129bbea1fa939c7b71b, type: 3}
-  m_Name: Loader
+  m_Name: Loader2
   m_EditorClassIdentifier: 
   m_unloadUnusedAfterUnload: 0
   m_defaultLoadParameters:
     m_addMode: 1
     m_physicsMode: 0
-    m_allowActivation: 1
+    m_allowActivation: 0
   m_defaultUnloadParameters:
     m_options: 1

--- a/Assets/UGF.Module.Scenes.Runtime.Tests/Resources/Loader2.asset.meta
+++ b/Assets/UGF.Module.Scenes.Runtime.Tests/Resources/Loader2.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 600ff64afcd85df4cb980b92cba88dda
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/UGF.Module.Scenes.Runtime.Tests/Resources/Module2.asset
+++ b/Assets/UGF.Module.Scenes.Runtime.Tests/Resources/Module2.asset
@@ -1,0 +1,22 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 93956d54c05347358c002a9ab8df22d9, type: 3}
+  m_Name: Module2
+  m_EditorClassIdentifier: 
+  m_unloadTrackedScenesOnUninitialize: 1
+  m_registerApplicationForScenes: 1
+  m_loaders:
+  - m_guid: 600ff64afcd85df4cb980b92cba88dda
+    m_asset: {fileID: 11400000, guid: 600ff64afcd85df4cb980b92cba88dda, type: 2}
+  m_groups:
+  - m_guid: b7a8683c9bcfb87478c5fc09d50e12ca
+    m_asset: {fileID: 11400000, guid: b7a8683c9bcfb87478c5fc09d50e12ca, type: 2}

--- a/Assets/UGF.Module.Scenes.Runtime.Tests/Resources/Module2.asset.meta
+++ b/Assets/UGF.Module.Scenes.Runtime.Tests/Resources/Module2.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 612631fa50d368e478dd8b6cefb6aee7
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/UGF.Module.Scenes.Runtime.Tests/TestSceneModule.cs
+++ b/Assets/UGF.Module.Scenes.Runtime.Tests/TestSceneModule.cs
@@ -44,7 +44,7 @@ namespace UGF.Module.Scenes.Runtime.Tests
             application.Initialize();
 
             var module = application.GetModule<ISceneModule>();
-            Scene scene = module.Load(id, SceneLoadParameters.DefaultAdditive);
+            Scene scene = module.Load(id);
 
             Assert.Contains(scene, module.Instances.Entries.Keys.ToArray());
             Assert.Contains(scene, ProviderInstance.Get<IProvider<Scene, IApplication>>().Entries.Keys.ToArray());
@@ -59,7 +59,7 @@ namespace UGF.Module.Scenes.Runtime.Tests
 
             if (unload)
             {
-                module.Unload(id, scene, SceneUnloadParameters.Default);
+                module.Unload(id, scene);
 
                 Assert.IsEmpty(module.Instances.Entries.Keys);
                 Assert.IsEmpty(ProviderInstance.Get<IProvider<Scene, IApplication>>().Entries.Keys);
@@ -82,7 +82,7 @@ namespace UGF.Module.Scenes.Runtime.Tests
             application.Initialize();
 
             var module = application.GetModule<ISceneModule>();
-            Task<Scene> task = module.LoadAsync(id, SceneLoadParameters.DefaultAdditive);
+            Task<Scene> task = module.LoadAsync(id);
 
             while (!task.IsCompleted)
             {
@@ -101,7 +101,7 @@ namespace UGF.Module.Scenes.Runtime.Tests
 
             if (unload)
             {
-                Task task2 = module.UnloadAsync(id, scene, SceneUnloadParameters.Default);
+                Task task2 = module.UnloadAsync(id, scene);
 
                 while (!task2.IsCompleted)
                 {
@@ -117,7 +117,7 @@ namespace UGF.Module.Scenes.Runtime.Tests
             }
         }
 
-        [TestCase("Module", "d39a9027b65879843ab7fc2c1a4a22af", ExpectedResult = null)]
+        [TestCase("Module2", "d39a9027b65879843ab7fc2c1a4a22af", ExpectedResult = null)]
         [UnityTest]
         public IEnumerator LoadAsyncActivation(string moduleName, string id)
         {
@@ -126,7 +126,7 @@ namespace UGF.Module.Scenes.Runtime.Tests
             application.Initialize();
 
             var module = application.GetModule<ISceneModule>();
-            Task<Scene> task = module.LoadAsync(id, SceneLoadParameters.DefaultAdditiveDisabled);
+            Task<Scene> task = module.LoadAsync(id);
 
             while (!task.IsCompleted)
             {

--- a/Packages/UGF.Module.Scenes/Runtime/ISceneLoader.cs
+++ b/Packages/UGF.Module.Scenes/Runtime/ISceneLoader.cs
@@ -6,9 +6,16 @@ namespace UGF.Module.Scenes.Runtime
 {
     public interface ISceneLoader
     {
+        ISceneLoadParameters DefaultLoadParameters { get; }
+        ISceneUnloadParameters DefaultUnloadParameters { get; }
+
+        Scene Load(string id, IContext context);
         Scene Load(string id, ISceneLoadParameters parameters, IContext context);
+        Task<Scene> LoadAsync(string id, IContext context);
         Task<Scene> LoadAsync(string id, ISceneLoadParameters parameters, IContext context);
+        void Unload(string id, Scene scene, IContext context);
         void Unload(string id, Scene scene, ISceneUnloadParameters parameters, IContext context);
+        Task UnloadAsync(string id, Scene scene, IContext context);
         Task UnloadAsync(string id, Scene scene, ISceneUnloadParameters parameters, IContext context);
     }
 }

--- a/Packages/UGF.Module.Scenes/Runtime/Loaders.Manager/ManagerSceneLoader.cs
+++ b/Packages/UGF.Module.Scenes/Runtime/Loaders.Manager/ManagerSceneLoader.cs
@@ -10,7 +10,12 @@ namespace UGF.Module.Scenes.Runtime.Loaders.Manager
     {
         public bool UnloadUnusedAfterUnload { get; }
 
-        public ManagerSceneLoader(bool unloadUnusedAfterUnload = true)
+        public ManagerSceneLoader(bool unloadUnusedAfterUnload = true) : this(SceneLoadParameters.Default, SceneUnloadParameters.Default, unloadUnusedAfterUnload)
+        {
+            UnloadUnusedAfterUnload = unloadUnusedAfterUnload;
+        }
+
+        public ManagerSceneLoader(ISceneLoadParameters defaultLoadParameters, ISceneUnloadParameters defaultUnloadParameters, bool unloadUnusedAfterUnload) : base(defaultLoadParameters, defaultUnloadParameters)
         {
             UnloadUnusedAfterUnload = unloadUnusedAfterUnload;
         }

--- a/Packages/UGF.Module.Scenes/Runtime/Loaders.Manager/ManagerSceneLoaderAsset.cs
+++ b/Packages/UGF.Module.Scenes/Runtime/Loaders.Manager/ManagerSceneLoaderAsset.cs
@@ -6,12 +6,16 @@ namespace UGF.Module.Scenes.Runtime.Loaders.Manager
     public class ManagerSceneLoaderAsset : SceneLoaderAsset
     {
         [SerializeField] private bool m_unloadUnusedAfterUnload;
+        [SerializeField] private SceneLoadParameters m_defaultLoadParameters = SceneLoadParameters.Default;
+        [SerializeField] private SceneUnloadParameters m_defaultUnloadParameters = SceneUnloadParameters.Default;
 
         public bool UnloadUnusedAfterUnload { get { return m_unloadUnusedAfterUnload; } set { m_unloadUnusedAfterUnload = value; } }
+        public SceneLoadParameters DefaultLoadParameters { get { return m_defaultLoadParameters; } }
+        public SceneUnloadParameters DefaultUnloadParameters { get { return m_defaultUnloadParameters; } }
 
         protected override ISceneLoader OnBuild()
         {
-            return new ManagerSceneLoader(m_unloadUnusedAfterUnload);
+            return new ManagerSceneLoader(m_defaultLoadParameters, m_defaultUnloadParameters, m_unloadUnusedAfterUnload);
         }
     }
 }

--- a/Packages/UGF.Module.Scenes/Runtime/Loaders.Manager/ManagerSceneLoaderAsset.cs
+++ b/Packages/UGF.Module.Scenes/Runtime/Loaders.Manager/ManagerSceneLoaderAsset.cs
@@ -1,4 +1,5 @@
 ﻿using UnityEngine;
+using UnityEngine.SceneManagement;
 
 namespace UGF.Module.Scenes.Runtime.Loaders.Manager
 {
@@ -6,8 +7,8 @@ namespace UGF.Module.Scenes.Runtime.Loaders.Manager
     public class ManagerSceneLoaderAsset : SceneLoaderAsset
     {
         [SerializeField] private bool m_unloadUnusedAfterUnload;
-        [SerializeField] private SceneLoadParameters m_defaultLoadParameters = SceneLoadParameters.Default;
-        [SerializeField] private SceneUnloadParameters m_defaultUnloadParameters = SceneUnloadParameters.Default;
+        [SerializeField] private SceneLoadParameters m_defaultLoadParameters = new SceneLoadParameters(LoadSceneMode.Single, LocalPhysicsMode.None);
+        [SerializeField] private SceneUnloadParameters m_defaultUnloadParameters = new SceneUnloadParameters(UnloadSceneOptions.UnloadAllEmbeddedSceneObjects);
 
         public bool UnloadUnusedAfterUnload { get { return m_unloadUnusedAfterUnload; } set { m_unloadUnusedAfterUnload = value; } }
         public SceneLoadParameters DefaultLoadParameters { get { return m_defaultLoadParameters; } }

--- a/Packages/UGF.Module.Scenes/Runtime/SceneLoaderBase.cs
+++ b/Packages/UGF.Module.Scenes/Runtime/SceneLoaderBase.cs
@@ -7,6 +7,23 @@ namespace UGF.Module.Scenes.Runtime
 {
     public abstract class SceneLoaderBase : ISceneLoader
     {
+        public ISceneLoadParameters DefaultLoadParameters { get; }
+        public ISceneUnloadParameters DefaultUnloadParameters { get; }
+
+        protected SceneLoaderBase(ISceneLoadParameters defaultLoadParameters, ISceneUnloadParameters defaultUnloadParameters)
+        {
+            DefaultLoadParameters = defaultLoadParameters ?? throw new ArgumentNullException(nameof(defaultLoadParameters));
+            DefaultUnloadParameters = defaultUnloadParameters ?? throw new ArgumentNullException(nameof(defaultUnloadParameters));
+        }
+
+        public Scene Load(string id, IContext context)
+        {
+            if (string.IsNullOrEmpty(id)) throw new ArgumentException("Value cannot be null or empty.", nameof(id));
+            if (context == null) throw new ArgumentNullException(nameof(context));
+
+            return OnLoad(id, context);
+        }
+
         public Scene Load(string id, ISceneLoadParameters parameters, IContext context)
         {
             if (string.IsNullOrEmpty(id)) throw new ArgumentException("Value cannot be null or empty.", nameof(id));
@@ -16,6 +33,14 @@ namespace UGF.Module.Scenes.Runtime
             return OnLoad(id, parameters, context);
         }
 
+        public Task<Scene> LoadAsync(string id, IContext context)
+        {
+            if (string.IsNullOrEmpty(id)) throw new ArgumentException("Value cannot be null or empty.", nameof(id));
+            if (context == null) throw new ArgumentNullException(nameof(context));
+
+            return OnLoadAsync(id, context);
+        }
+
         public Task<Scene> LoadAsync(string id, ISceneLoadParameters parameters, IContext context)
         {
             if (string.IsNullOrEmpty(id)) throw new ArgumentException("Value cannot be null or empty.", nameof(id));
@@ -23,6 +48,15 @@ namespace UGF.Module.Scenes.Runtime
             if (context == null) throw new ArgumentNullException(nameof(context));
 
             return OnLoadAsync(id, parameters, context);
+        }
+
+        public void Unload(string id, Scene scene, IContext context)
+        {
+            if (string.IsNullOrEmpty(id)) throw new ArgumentException("Value cannot be null or empty.", nameof(id));
+            if (!scene.IsValid()) throw new ArgumentException("Value should be valid.", nameof(scene));
+            if (context == null) throw new ArgumentNullException(nameof(context));
+
+            OnUnload(id, scene, context);
         }
 
         public void Unload(string id, Scene scene, ISceneUnloadParameters parameters, IContext context)
@@ -35,6 +69,15 @@ namespace UGF.Module.Scenes.Runtime
             OnUnload(id, scene, parameters, context);
         }
 
+        public Task UnloadAsync(string id, Scene scene, IContext context)
+        {
+            if (string.IsNullOrEmpty(id)) throw new ArgumentException("Value cannot be null or empty.", nameof(id));
+            if (!scene.IsValid()) throw new ArgumentException("Value should be valid.", nameof(scene));
+            if (context == null) throw new ArgumentNullException(nameof(context));
+
+            return OnUnloadAsync(id, scene, context);
+        }
+
         public Task UnloadAsync(string id, Scene scene, ISceneUnloadParameters parameters, IContext context)
         {
             if (string.IsNullOrEmpty(id)) throw new ArgumentException("Value cannot be null or empty.", nameof(id));
@@ -43,6 +86,26 @@ namespace UGF.Module.Scenes.Runtime
             if (context == null) throw new ArgumentNullException(nameof(context));
 
             return OnUnloadAsync(id, scene, parameters, context);
+        }
+
+        protected virtual Scene OnLoad(string id, IContext context)
+        {
+            return OnLoad(id, DefaultLoadParameters, context);
+        }
+
+        protected virtual Task<Scene> OnLoadAsync(string id, IContext context)
+        {
+            return OnLoadAsync(id, DefaultLoadParameters, context);
+        }
+
+        protected virtual void OnUnload(string id, Scene scene, IContext context)
+        {
+            OnUnload(id, scene, DefaultUnloadParameters, context);
+        }
+
+        protected virtual Task OnUnloadAsync(string id, Scene scene, IContext context)
+        {
+            return OnUnloadAsync(id, scene, DefaultUnloadParameters, context);
         }
 
         protected abstract Scene OnLoad(string id, ISceneLoadParameters parameters, IContext context);

--- a/Packages/UGF.Module.Scenes/Runtime/SceneLoader`1.cs
+++ b/Packages/UGF.Module.Scenes/Runtime/SceneLoader`1.cs
@@ -2,5 +2,12 @@
 {
     public abstract class SceneLoader<TInfo> : SceneLoader<TInfo, ISceneLoadParameters, ISceneUnloadParameters> where TInfo : class, ISceneInfo
     {
+        protected SceneLoader() : this(SceneLoadParameters.Default, SceneUnloadParameters.Default)
+        {
+        }
+
+        protected SceneLoader(ISceneLoadParameters defaultLoadParameters, ISceneUnloadParameters defaultUnloadParameters) : base(defaultLoadParameters, defaultUnloadParameters)
+        {
+        }
     }
 }

--- a/Packages/UGF.Module.Scenes/Runtime/SceneLoader`3.cs
+++ b/Packages/UGF.Module.Scenes/Runtime/SceneLoader`3.cs
@@ -10,6 +10,10 @@ namespace UGF.Module.Scenes.Runtime
         where TLoadParameters : class, ISceneLoadParameters
         where TUnloadParameters : class, ISceneUnloadParameters
     {
+        protected SceneLoader(TLoadParameters defaultLoadParameters, TUnloadParameters defaultUnloadParameters) : base(defaultLoadParameters, defaultUnloadParameters)
+        {
+        }
+
         protected override Scene OnLoad(string id, ISceneLoadParameters parameters, IContext context)
         {
             var provider = context.Get<IProvider<string, ISceneInfo>>();

--- a/Packages/UGF.Module.Scenes/Runtime/SceneModuleExtensions.cs
+++ b/Packages/UGF.Module.Scenes/Runtime/SceneModuleExtensions.cs
@@ -1,9 +1,45 @@
 ﻿using System;
+using System.Threading.Tasks;
+using UnityEngine.SceneManagement;
 
 namespace UGF.Module.Scenes.Runtime
 {
     public static class SceneModuleExtensions
     {
+        public static ISceneLoadParameters GetDefaultLoadParametersByScene(this ISceneModule sceneModule, string id)
+        {
+            return TryGetDefaultLoadParametersByScene(sceneModule, id, out ISceneLoadParameters parameters) ? parameters : throw new ArgumentException($"Scene load parameters not found by the specified scene id: '{id}'.");
+        }
+
+        public static bool TryGetDefaultLoadParametersByScene(this ISceneModule sceneModule, string id, out ISceneLoadParameters parameters)
+        {
+            if (TryGetLoaderByScene(sceneModule, id, out ISceneLoader loader))
+            {
+                parameters = loader.DefaultLoadParameters;
+                return true;
+            }
+
+            parameters = null;
+            return false;
+        }
+
+        public static ISceneUnloadParameters GetDefaultUnloadParametersByScene(this ISceneModule sceneModule, string id)
+        {
+            return TryGetDefaultUnloadParametersByScene(sceneModule, id, out ISceneUnloadParameters parameters) ? parameters : throw new ArgumentException($"Scene unload parameters not found by the specified scene id: '{id}'.");
+        }
+
+        public static bool TryGetDefaultUnloadParametersByScene(this ISceneModule sceneModule, string id, out ISceneUnloadParameters parameters)
+        {
+            if (TryGetLoaderByScene(sceneModule, id, out ISceneLoader loader))
+            {
+                parameters = loader.DefaultUnloadParameters;
+                return true;
+            }
+
+            parameters = null;
+            return false;
+        }
+
         public static ISceneLoader GetLoaderByScene(this ISceneModule sceneModule, string id)
         {
             return TryGetLoaderByScene(sceneModule, id, out ISceneLoader loader) ? loader : throw new ArgumentException($"Scene loader not found by the specified scene id: '{id}'.");
@@ -15,6 +51,42 @@ namespace UGF.Module.Scenes.Runtime
 
             loader = default;
             return sceneModule.Scenes.TryGet(id, out ISceneInfo scene) && sceneModule.Loaders.TryGet(scene.LoaderId, out loader);
+        }
+
+        public static Scene Load(this ISceneModule sceneModule, string id)
+        {
+            if (sceneModule == null) throw new ArgumentNullException(nameof(sceneModule));
+
+            ISceneLoadParameters parameters = GetDefaultLoadParametersByScene(sceneModule, id);
+
+            return sceneModule.Load(id, parameters);
+        }
+
+        public static Task<Scene> LoadAsync(this ISceneModule sceneModule, string id)
+        {
+            if (sceneModule == null) throw new ArgumentNullException(nameof(sceneModule));
+
+            ISceneLoadParameters parameters = GetDefaultLoadParametersByScene(sceneModule, id);
+
+            return sceneModule.LoadAsync(id, parameters);
+        }
+
+        public static void Unload(this ISceneModule sceneModule, string id, Scene scene)
+        {
+            if (sceneModule == null) throw new ArgumentNullException(nameof(sceneModule));
+
+            ISceneUnloadParameters parameters = GetDefaultUnloadParametersByScene(sceneModule, id);
+
+            sceneModule.Unload(id, scene, parameters);
+        }
+
+        public static Task UnloadAsync(this ISceneModule sceneModule, string id, Scene scene)
+        {
+            if (sceneModule == null) throw new ArgumentNullException(nameof(sceneModule));
+
+            ISceneUnloadParameters parameters = GetDefaultUnloadParametersByScene(sceneModule, id);
+
+            return sceneModule.UnloadAsync(id, scene, parameters);
         }
     }
 }


### PR DESCRIPTION
- Add `DefaultLoadParameters` and `DefaultUnloadParameters` properties for `ISceneLoader` interface and class implementations.
- Add `Load`, `LoadAsync`, `Unload` and `UnloadAsync` method overloads without load and unload parameters argument, which use default parameters from loader.
- Add implementation of default parameters properties for `SceneLoaderBase` abstract class and virtual methods of load and unload overloads.
- Add constructor with default parameters for `ManagerSceneLoader` class.
- Add `DefaultLoadParameters` and `DefaultUnloadParameters` properties for `ManagerSceneLoaderAsset` asset.
- Add `TryGetDefaultLoadParametersByScene`, `GetDefaultLoadParametersByScene`, `TryGetDefaultUnloadParametersByScene` and `GetDefaultUnloadParametersByScene` extension methods for `ISceneModule` to get default parameters of loader by the specified scene id.
- Add `Load`, `LoadAsync`, `Unload` and `UnloadAsync` extension methods for `ISceneModule` to load and unload scenes without parameters arguments, which use default parameters from loader.