### PR TITLE
Add refresh all groups in project settings

### DIFF
--- a/Packages/UGF.Module.Scenes/Editor/Loaders.Manager/ManagerSceneEditorBuildPreprocess.cs
+++ b/Packages/UGF.Module.Scenes/Editor/Loaders.Manager/ManagerSceneEditorBuildPreprocess.cs
@@ -1,4 +1,5 @@
 ﻿using UGF.CustomSettings.Editor;
+using UnityEditor;
 using UnityEditor.Build;
 using UnityEditor.Build.Reporting;
 
@@ -14,7 +15,8 @@ namespace UGF.Module.Scenes.Editor.Loaders.Manager
 
             if (settings.Exists() && settings.GetData().UpdateAllGroupsOnBuild)
             {
-                ManagerSceneEditorUtility.UpdateAllSceneGroups();
+                ManagerSceneEditorUtility.UpdateSceneGroupAll();
+                AssetDatabase.SaveAssets();
             }
         }
     }

--- a/Packages/UGF.Module.Scenes/Editor/Loaders.Manager/ManagerSceneEditorProgress.cs
+++ b/Packages/UGF.Module.Scenes/Editor/Loaders.Manager/ManagerSceneEditorProgress.cs
@@ -1,0 +1,28 @@
+﻿using UnityEditor;
+
+namespace UGF.Module.Scenes.Editor.Loaders.Manager
+{
+    internal static class ManagerSceneEditorProgress
+    {
+        internal static void StartUpdateSceneGroupAll()
+        {
+            int progressId = Progress.Start("Update All Manager Scene Groups", string.Empty, Progress.Options.Indefinite);
+
+            try
+            {
+                ManagerSceneEditorUtility.UpdateSceneGroupAll();
+
+                Progress.Finish(progressId);
+            }
+            catch
+            {
+                Progress.Finish(progressId, Progress.Status.Failed);
+                throw;
+            }
+            finally
+            {
+                AssetDatabase.SaveAssets();
+            }
+        }
+    }
+}

--- a/Packages/UGF.Module.Scenes/Editor/Loaders.Manager/ManagerSceneEditorProgress.cs.meta
+++ b/Packages/UGF.Module.Scenes/Editor/Loaders.Manager/ManagerSceneEditorProgress.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 97e2913b5ad643e4a7e3ff8c457916be
+timeCreated: 1633537857

--- a/Packages/UGF.Module.Scenes/Editor/Loaders.Manager/ManagerSceneEditorSettingsDataEditor.cs
+++ b/Packages/UGF.Module.Scenes/Editor/Loaders.Manager/ManagerSceneEditorSettingsDataEditor.cs
@@ -1,0 +1,47 @@
+﻿using UGF.EditorTools.Editor.IMGUI.Scopes;
+using UnityEditor;
+using UnityEngine;
+
+namespace UGF.Module.Scenes.Editor.Loaders.Manager
+{
+    [CustomEditor(typeof(ManagerSceneEditorSettingsData), true)]
+    internal class ManagerSceneEditorSettingsDataEditor : UnityEditor.Editor
+    {
+        private SerializedProperty m_propertyUpdateAllGroupsOnBuild;
+        private Styles m_styles;
+
+        private class Styles
+        {
+            public GUIContent RefreshAllContent { get; } = new GUIContent("Refresh All", "Refresh all groups in project to update address for each entry.");
+        }
+
+        private void OnEnable()
+        {
+            m_propertyUpdateAllGroupsOnBuild = serializedObject.FindProperty("m_updateAllGroupsOnBuild");
+        }
+
+        public override void OnInspectorGUI()
+        {
+            m_styles ??= new Styles();
+
+            using (new SerializedObjectUpdateScope(serializedObject))
+            {
+                EditorGUILayout.PropertyField(m_propertyUpdateAllGroupsOnBuild);
+            }
+
+            EditorGUILayout.Space();
+
+            using (new EditorGUILayout.HorizontalScope())
+            {
+                GUILayout.FlexibleSpace();
+
+                if (GUILayout.Button(m_styles.RefreshAllContent))
+                {
+                    ManagerSceneEditorProgress.StartUpdateSceneGroupAll();
+                }
+
+                EditorGUILayout.Space();
+            }
+        }
+    }
+}

--- a/Packages/UGF.Module.Scenes/Editor/Loaders.Manager/ManagerSceneEditorSettingsDataEditor.cs.meta
+++ b/Packages/UGF.Module.Scenes/Editor/Loaders.Manager/ManagerSceneEditorSettingsDataEditor.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: cc6acaea677a4d6f8504ce46907b7db7
+timeCreated: 1633537581

--- a/Packages/UGF.Module.Scenes/Editor/Loaders.Manager/ManagerSceneEditorUtility.Deprecated.cs
+++ b/Packages/UGF.Module.Scenes/Editor/Loaders.Manager/ManagerSceneEditorUtility.Deprecated.cs
@@ -1,0 +1,13 @@
+﻿using System;
+
+namespace UGF.Module.Scenes.Editor.Loaders.Manager
+{
+    public static partial class ManagerSceneEditorUtility
+    {
+        [Obsolete("UpdateAllSceneGroups has been deprecated. Use UpdateSceneGroupAll method instead.")]
+        public static void UpdateAllSceneGroups()
+        {
+            ManagerSceneEditorProgress.StartUpdateSceneGroupAll();
+        }
+    }
+}

--- a/Packages/UGF.Module.Scenes/Editor/Loaders.Manager/ManagerSceneEditorUtility.Deprecated.cs.meta
+++ b/Packages/UGF.Module.Scenes/Editor/Loaders.Manager/ManagerSceneEditorUtility.Deprecated.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 7c87af061ebc475cb115b2330cf884bc
+timeCreated: 1633537957

--- a/Packages/UGF.Module.Scenes/Editor/Loaders.Manager/ManagerSceneEditorUtility.cs
+++ b/Packages/UGF.Module.Scenes/Editor/Loaders.Manager/ManagerSceneEditorUtility.cs
@@ -5,7 +5,7 @@ using Object = UnityEngine.Object;
 
 namespace UGF.Module.Scenes.Editor.Loaders.Manager
 {
-    public static class ManagerSceneEditorUtility
+    public static partial class ManagerSceneEditorUtility
     {
         public static bool IsSceneGroupHasMissingEntries(ManagerSceneGroupAsset group)
         {
@@ -33,6 +33,25 @@ namespace UGF.Module.Scenes.Editor.Loaders.Manager
             return false;
         }
 
+        public static void UpdateSceneGroupAll()
+        {
+            string[] guids = AssetDatabase.FindAssets($"t:{nameof(ManagerSceneGroupAsset)}");
+
+            for (int i = 0; i < guids.Length; i++)
+            {
+                string guid = guids[i];
+                string path = AssetDatabase.GUIDToAssetPath(guid);
+                var asset = AssetDatabase.LoadAssetAtPath<ManagerSceneGroupAsset>(path);
+
+                if (asset != null)
+                {
+                    UpdateSceneGroupEntries(asset);
+
+                    EditorUtility.SetDirty(asset);
+                }
+            }
+        }
+
         public static void UpdateSceneGroupEntries(ManagerSceneGroupAsset group)
         {
             if (group == null) throw new ArgumentNullException(nameof(group));
@@ -52,43 +71,6 @@ namespace UGF.Module.Scenes.Editor.Loaders.Manager
                         group.Scenes[i] = entry;
                     }
                 }
-            }
-        }
-
-        public static void UpdateAllSceneGroups()
-        {
-            int progressId = Progress.Start("Update All Manager Scene Groups");
-
-            try
-            {
-                string[] guids = AssetDatabase.FindAssets($"t:{nameof(ManagerSceneGroupAsset)}");
-
-                for (int i = 0; i < guids.Length; i++)
-                {
-                    Progress.Report(progressId, i, guids.Length);
-
-                    string guid = guids[i];
-                    string path = AssetDatabase.GUIDToAssetPath(guid);
-                    var asset = AssetDatabase.LoadAssetAtPath<ManagerSceneGroupAsset>(path);
-
-                    if (asset != null)
-                    {
-                        UpdateSceneGroupEntries(asset);
-
-                        EditorUtility.SetDirty(asset);
-                    }
-                }
-
-                Progress.Finish(progressId);
-            }
-            catch
-            {
-                Progress.Finish(progressId, Progress.Status.Failed);
-                throw;
-            }
-            finally
-            {
-                AssetDatabase.SaveAssets();
             }
         }
     }

--- a/Packages/UGF.Module.Scenes/Editor/Loaders.Manager/ManagerSceneGroupAssetEditor.cs
+++ b/Packages/UGF.Module.Scenes/Editor/Loaders.Manager/ManagerSceneGroupAssetEditor.cs
@@ -58,7 +58,7 @@ namespace UGF.Module.Scenes.Editor.Loaders.Manager
 
                 if (GUILayout.Button(m_styles.RefreshAllContent))
                 {
-                    ManagerSceneEditorUtility.UpdateAllSceneGroups();
+                    ManagerSceneEditorProgress.StartUpdateSceneGroupAll();
                 }
 
                 if (GUILayout.Button(m_styles.RefreshContent))

--- a/Packages/manifest.json
+++ b/Packages/manifest.json
@@ -1,7 +1,7 @@
 {
   "dependencies": {
     "com.unity.ide.rider": "3.0.7",
-    "com.unity.test-framework": "1.1.24"
+    "com.unity.test-framework": "1.1.29"
   },
   "scopedRegistries": [
     {

--- a/Packages/packages-lock.json
+++ b/Packages/packages-lock.json
@@ -103,7 +103,7 @@
       "url": "https://packages.unity.com"
     },
     "com.unity.test-framework": {
-      "version": "1.1.24",
+      "version": "1.1.29",
       "depth": 0,
       "source": "registry",
       "dependencies": {

--- a/ProjectSettings/ProjectVersion.txt
+++ b/ProjectSettings/ProjectVersion.txt
@@ -1,2 +1,2 @@
-m_EditorVersion: 2021.1.7f1
-m_EditorVersionWithRevision: 2021.1.7f1 (d91830b65d9b)
+m_EditorVersion: 2021.1.19f1
+m_EditorVersionWithRevision: 2021.1.19f1 (5f5eb8bbdc25)


### PR DESCRIPTION
- Add `Refresh All` button in project settings to refresh all groups in the project.
- Deprecate `ManagerSceneEditorUtility.UpdateAllSceneGroups()` method, use `UpdateSceneGroupAll()` method instead.